### PR TITLE
INTEXT-197: The <int-aws:s3-outbound-channel-adapter> doesn't have "p…

### DIFF
--- a/src/main/resources/org/springframework/integration/aws/config/xml/spring-integration-aws-1.0.xsd
+++ b/src/main/resources/org/springframework/integration/aws/config/xml/spring-integration-aws-1.0.xsd
@@ -72,16 +72,7 @@
 				<xsd:element ref="integration:poller" minOccurs="0" maxOccurs="1"/>
 				<xsd:element name="request-handler-advice-chain" type="integration:handlerAdviceChainType" minOccurs="0" maxOccurs="1"/>
 			</xsd:choice>
-			<xsd:attribute name="id" type="xsd:string"/>
-			<xsd:attribute name="channel" type="xsd:string">
-				<xsd:annotation>
-					<xsd:appinfo>
-						<tool:annotation kind="ref">
-							<tool:expected-type type="org.springframework.integration.core.MessageChannel"/>
-						</tool:annotation>
-					</xsd:appinfo>
-				</xsd:annotation>
-			</xsd:attribute>
+			<xsd:attributeGroup ref="integration:channelAdapterAttributes"/>
 			<xsd:attributeGroup ref="awsAdaptersCommonAttributes"/>
 			<xsd:attribute name="bucket" type="xsd:string" use="required">
 				<xsd:annotation>
@@ -189,7 +180,6 @@
 				</xsd:annotation>
 			</xsd:attribute>
 
-			<xsd:attribute name="auto-startup" type="xsd:string" default="true"/>
 			<xsd:attribute name="order">
 				<xsd:annotation>
 					<xsd:documentation>

--- a/src/test/java/org/springframework/integration/aws/s3/config/xml/AmazonS3OutboundChannelAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/aws/s3/config/xml/AmazonS3OutboundChannelAdapterParserTests.java
@@ -23,7 +23,6 @@ import static org.springframework.integration.test.util.TestUtils.getPropertyVal
 import java.net.URI;
 
 import org.junit.Test;
-
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.BeanDefinitionStoreException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -159,6 +158,22 @@ public class AmazonS3OutboundChannelAdapterParserTests {
 		MessageHandler handler = getPropertyValue(consumer, "handler", MessageHandler.class);
 		handler.handleMessage(new GenericMessage<String>("String content: Test AWS advice chain"));
 		assertEquals(1, adviceCalled);
+		ctx.destroy();
+	}
+
+	/**
+	 * Test case for the xml definition with the Channel Attributes.
+	 */
+	@Test
+	public void withChannelAttributeImplementation() {
+		ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("classpath:s3-valid-outbound-cases.xml");
+		EventDrivenConsumer consumer = ctx.getBean("withChannelAdapterAttributes", EventDrivenConsumer.class);
+		AmazonS3MessageHandler handler = getPropertyValue(consumer, "handler", AmazonS3MessageHandler.class);
+		assertEquals(DefaultAmazonS3Operations.class, getPropertyValue(handler, "operations").getClass());
+        assertEquals("input", getPropertyValue(consumer, "inputChannel.beanName", String.class));
+        assertEquals("US-ASCII", getPropertyValue(handler, "charset", String.class));
+		assertEquals(100, getPropertyValue(consumer, "phase", Integer.class).intValue());
+        assertEquals(true, getPropertyValue(consumer, "autoStartup", Boolean.class));
 		ctx.destroy();
 	}
 

--- a/src/test/resources/s3-valid-outbound-cases.xml
+++ b/src/test/resources/s3-valid-outbound-cases.xml
@@ -68,6 +68,21 @@
 		</int-aws:request-handler-advice-chain>
 	</int-aws:s3-outbound-channel-adapter>
 
+	<int-aws:s3-outbound-channel-adapter
+			id="withChannelAdapterAttributes"
+			channel="input"
+			bucket="TestBucket"
+			accessKey="dummy"
+			secretKey="dummy"
+			remote-directory="/"
+			charset="US-ASCII"
+			phase="100"
+			auto-startup="true"
+			thread-pool-executor="executor"
+			multipart-upload-threshold="5120"
+			temporary-suffix=".write"
+			file-name-generation-expression="headers['name']"/>
+
 	<bean id="queue" class="java.util.concurrent.ArrayBlockingQueue">
 		<constructor-arg value="10"/>
 	</bean>


### PR DESCRIPTION
INTEXT-197: The <int-aws:s3-outbound-channel-adapter> doesn't have "phase" attribute
https://jira.spring.io/browse/INTEXT-197

* Modified the org/springframework/integration/aws/config/xml/spring-integration-aws-1.0.xsd to add channelAdapterAttributes to expose 
phase attribute in s3 outbound adapter.
* Modified AmazonS3OutboundChannelAdapterParserTests - Added Unit Test Class to test the channel attributes.
* Modified s3-valid-outbound-cases.xml - Added separate definition withChannelAdapterAttributes for phase attribute.