### PR TITLE
Typo: Change nane --> name

### DIFF
--- a/src/main/java/org/springframework/integration/aws/s3/core/S3ObjectSummary.java
+++ b/src/main/java/org/springframework/integration/aws/s3/core/S3ObjectSummary.java
@@ -28,7 +28,7 @@ import java.util.Date;
 public interface S3ObjectSummary {
 
 	/**
-	 * Gets the Bucket nane in which the object is kept on S3
+	 * Gets the Bucket name in which the object is kept on S3
 	 */
 	String getBucketName();
 


### PR DESCRIPTION
Change the typo in the java doc of getBucketName() from 'nane' --> 'name'.