### PR TITLE
Add `ResourceIdResolver` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Other interested clients may subscribe using different protocols like HTTP/HTTPS
 receive the messages. Plus mobile devices can be registered as subscribers from the AWS Management Console.
 
 Unfortunately [Spring Cloud AWS][] doesn't provide flexible components which can be used from the channel adapter
-implementations, but Amazon SNS API is pretty simple, from other side. Hence Spring Integration AWS SNS Support is
+implementations, but Amazon SNS API is pretty simple, on the other hand. Hence Spring Integration AWS SNS Support is
 straightforward and just allows to provide channel adapter foundation for Spring Integration applications.
 
 Since e-mail, SMS and mobile devices subscription/unsubscription confirmation is out of the Spring Integration
@@ -353,15 +353,15 @@ HTTP headers, populated by the `DefaultHttpHeaderMapper`, are available for the 
 ###Outbound Channel Adapter
 
 The `SnsMessageHandler` (`<int-aws:sns-outbound-channel-adapter>`) is a simple one-way Outbound Channel Adapter
-to send Topic Notification using `AmasonSNS` service.
+to send Topic Notification using `AmazonSNS` service.
 
 This Channel Adapter (`MessageHandler`) accepts these options:
 
-- `topic-arn` (`topic-arn-expression`) - the SNS Topic to send notification for. The `ResourceIdResolver` can be used
-from the SpEL definition to determine the target Topic Arn from the local logical name;
+- `topic-arn` (`topic-arn-expression`) - the SNS Topic to send notification for.
 - `subject` (`subject-expression`) - the SNS Notification Subject;
 - `body-expression` - the SpEL expression to evaluate the `message` property for the
 `com.amazonaws.services.sns.model.PublishRequest`.
+- `resource-id-resolver` - a `ResourceIdResolver` bean reference to resolve logical topic names to physical resource ids;
 
 See `SnsMessageHandler` JavaDocs for more information.
 

--- a/src/main/java/org/springframework/integration/aws/config/xml/S3OutboundGatewayParser.java
+++ b/src/main/java/org/springframework/integration/aws/config/xml/S3OutboundGatewayParser.java
@@ -97,6 +97,7 @@ public class S3OutboundGatewayParser extends AbstractConsumerEndpointParser {
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "resource-id-resolver");
 
 		return builder;
 	}

--- a/src/main/java/org/springframework/integration/aws/config/xml/SnsOutboundGatewayParser.java
+++ b/src/main/java/org/springframework/integration/aws/config/xml/SnsOutboundGatewayParser.java
@@ -65,6 +65,7 @@ public class SnsOutboundGatewayParser extends AbstractConsumerEndpointParser {
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "reply-timeout", "sendTimeout");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "reply-channel", "outputChannel");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "resource-id-resolver");
 
 		return builder;
 	}

--- a/src/main/java/org/springframework/integration/aws/support/S3SessionFactory.java
+++ b/src/main/java/org/springframework/integration/aws/support/S3SessionFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.aws.support;
 
+import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.remote.session.SharedSessionCapable;
 import org.springframework.util.Assert;
@@ -40,8 +41,12 @@ public class S3SessionFactory implements SessionFactory<S3ObjectSummary>, Shared
 	}
 
 	public S3SessionFactory(AmazonS3 amazonS3) {
+		this(amazonS3, null);
+	}
+
+	public S3SessionFactory(AmazonS3 amazonS3, ResourceIdResolver resourceIdResolver) {
 		Assert.notNull(amazonS3, "'amazonS3' must not be null.");
-		this.s3Session = new S3Session(amazonS3);
+		this.s3Session = new S3Session(amazonS3, resourceIdResolver);
 	}
 
 	@Override

--- a/src/main/resources/org/springframework/integration/aws/config/spring-integration-aws-1.0.xsd
+++ b/src/main/resources/org/springframework/integration/aws/config/spring-integration-aws-1.0.xsd
@@ -232,6 +232,18 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="resource-id-resolver">
+			<xsd:annotation>
+				<xsd:documentation>
+					The 'org.springframework.cloud.aws.core.env.ResourceIdResolver' bean reference.
+				</xsd:documentation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+					</tool:annotation>
+				</xsd:appinfo>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:complexType>
 
 	<xsd:simpleType name="s3CommandType">
@@ -830,8 +842,6 @@
 					This attribute isn't mandatory and the the topic can be specified on the
 					'com.amazonaws.services.sns.model.PublishRequest'
 					payload of the request Message.
-					The 'org.springframework.cloud.aws.core.env.ResourceIdResolver' bean can be used from
-					the expression to resolve logical topic name to the real ARN.
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/src/test/java/org/springframework/integration/aws/config/xml/S3MessageHandlerParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/S3MessageHandlerParserTests-context.xml
@@ -17,6 +17,10 @@
 		<constructor-arg value="org.springframework.integration.aws.outbound.S3MessageHandler$UploadMetadataProvider"/>
 	</bean>
 
+	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver" />
+	</bean>
+
 	<int-aws:s3-outbound-channel-adapter s3="s3"
 										 auto-startup="false"
 										 channel="errorChannel"
@@ -29,7 +33,8 @@
 										 destination-key-expression="'baz'"
 										 object-acl-expression="'qux'"
 										 progress-listener="s3ProgressListener"
-										 upload-metadata-provider="uploadMetadataProvider"/>
+										 upload-metadata-provider="uploadMetadataProvider"
+										 resource-id-resolver="resourceIdResolver" />
 
 	<bean id="transferManager" class="com.amazonaws.services.s3.transfer.TransferManager"/>
 

--- a/src/test/java/org/springframework/integration/aws/config/xml/S3MessageHandlerParserTests.java
+++ b/src/test/java/org/springframework/integration/aws/config/xml/S3MessageHandlerParserTests.java
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.aws.outbound.S3MessageHandler;
@@ -79,6 +80,9 @@ public class S3MessageHandlerParserTests {
 	private S3MessageHandler.UploadMetadataProvider uploadMetadataProvider;
 
 	@Autowired
+	private ResourceIdResolver resourceIdResolver;
+
+	@Autowired
 	private BeanFactory beanFactory;
 
 	@Test
@@ -110,6 +114,8 @@ public class S3MessageHandlerParserTests {
 				.isSameAs(this.progressListener);
 		assertThat(TestUtils.getPropertyValue(this.s3OutboundChannelAdapterHandler, "uploadMetadataProvider"))
 				.isSameAs(this.uploadMetadataProvider);
+		assertThat(TestUtils.getPropertyValue(this.s3OutboundChannelAdapterHandler, "resourceIdResolver"))
+				.isSameAs(this.resourceIdResolver);
 
 		assertThat(this.s3OutboundChannelAdapter.getPhase()).isEqualTo(100);
 		assertThat(this.s3OutboundChannelAdapter.isAutoStartup()).isFalse();

--- a/src/test/java/org/springframework/integration/aws/config/xml/SnsOutboundChannelAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SnsOutboundChannelAdapterParserTests-context.xml
@@ -11,7 +11,14 @@
 		<constructor-arg value="com.amazonaws.services.sns.AmazonSNS"/>
 	</bean>
 
-	<int-aws:sns-outbound-channel-adapter id="defaultAdapter" sns="amazonSns">
+	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver" />
+	</bean>
+
+	<int-aws:sns-outbound-channel-adapter
+			id="defaultAdapter"
+			sns="amazonSns"
+			resource-id-resolver="resourceIdResolver">
 		<int-aws:request-handler-advice-chain>
 			<bean class="org.springframework.integration.handler.advice.RequestHandlerRetryAdvice"/>
 		</int-aws:request-handler-advice-chain>
@@ -27,6 +34,7 @@
 			topic-arn="foo"
 			subject="bar"
 			body-expression="payload.toUpperCase()"
+			resource-id-resolver="resourceIdResolver"
 			auto-startup="false"
 			phase="201"/>
 

--- a/src/test/java/org/springframework/integration/aws/config/xml/SnsOutboundChannelAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SnsOutboundChannelAdapterParserTests.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.expression.Expression;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.handler.advice.RequestHandlerRetryAdvice;
@@ -75,6 +76,9 @@ public class SnsOutboundChannelAdapterParserTests {
 	@Qualifier("snsGateway.handler")
 	private MessageHandler snsGatewayHandler;
 
+	@Autowired
+	private ResourceIdResolver resourceIdResolver;
+
 	@Test
 	public void testSnsOutboundChannelAdapterDefaultParser() throws Exception {
 		Object handler = TestUtils.getPropertyValue(this.defaultAdapter, "handler");
@@ -93,16 +97,20 @@ public class SnsOutboundChannelAdapterParserTests {
 		assertThat(TestUtils.getPropertyValue(this.defaultAdapterHandler, "topicArnExpression")).isNull();
 		assertThat(TestUtils.getPropertyValue(this.defaultAdapterHandler, "subjectExpression")).isNull();
 		assertThat(TestUtils.getPropertyValue(this.defaultAdapterHandler, "bodyExpression")).isNull();
+		assertThat(TestUtils.getPropertyValue(this.defaultAdapterHandler, "resourceIdResolver"))
+				.isSameAs(this.resourceIdResolver);
 	}
 
 	@Test
-	public void testSnsOutboundChannelAdapterParser() {
+	public void testSnsOutboundGatewayParser() {
 		assertThat(TestUtils.getPropertyValue(this.snsGateway, "inputChannel")).isSameAs(this.notificationChannel);
 		assertThat(TestUtils.getPropertyValue(this.snsGateway, "handler")).isSameAs(this.snsGatewayHandler);
 		assertThat(TestUtils.getPropertyValue(this.snsGateway, "autoStartup", Boolean.class)).isFalse();
 		assertThat(TestUtils.getPropertyValue(this.snsGateway, "phase", Integer.class)).isEqualTo(201);
 		assertThat(TestUtils.getPropertyValue(this.snsGatewayHandler, "produceReply", Boolean.class)).isTrue();
 		assertThat(TestUtils.getPropertyValue(this.snsGatewayHandler, "outputChannel")).isSameAs(this.errorChannel);
+		assertThat(TestUtils.getPropertyValue(this.snsGatewayHandler, "resourceIdResolver"))
+				.isSameAs(this.resourceIdResolver);
 
 		assertThat(TestUtils.getPropertyValue(this.snsGatewayHandler, "amazonSns")).isSameAs(this.amazonSns);
 		assertThat(TestUtils.getPropertyValue(this.snsGatewayHandler, "evaluationContext")).isNotNull();

--- a/src/test/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapterTests.java
+++ b/src/test/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapterTests.java
@@ -167,7 +167,7 @@ public class SnsInboundChannelAdapterTests {
 		}
 
 		@Bean
-		public HttpRequestHandler sqsMessageDrivenChannelAdapter() {
+		public HttpRequestHandler snsInboundChannelAdapter() {
 			SnsInboundChannelAdapter adapter = new SnsInboundChannelAdapter(amazonSns(), "/mySampleTopic");
 			adapter.setRequestChannel(inputChannel());
 			adapter.setHandleNotificationStatus(true);


### PR DESCRIPTION
I many cases we deal in application just with simple logical name for the target AWS entities, e.g. `myQueue`, `testBucket`.
Actually they must be resolved into the physical resources against the current environment.
E.g. the same  S3 `testBucket` ca be fully different in different regions.
 The SQS queue must be resolved into the resources with the current `Stack` context.