### PR TITLE
Added text/plain as supported content type for SNS inbound notification

### DIFF
--- a/src/main/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapter.java
@@ -28,6 +28,7 @@ import org.springframework.expression.Expression;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.integration.aws.support.AwsHeaders;
@@ -42,6 +43,7 @@ import org.springframework.web.multipart.MultipartResolver;
 
 import com.amazonaws.services.sns.AmazonSNS;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.sun.javafx.collections.ImmutableObservableList;
 
 /**
  * The {@link HttpRequestHandlingMessagingGateway} extension for the Amazon WS SNS HTTP(S) endpoints.
@@ -89,6 +91,8 @@ public class SnsInboundChannelAdapter extends HttpRequestHandlingMessagingGatewa
 		requestMapping.setMethods(HttpMethod.POST);
 		requestMapping.setHeaders("x-amz-sns-message-type");
 		requestMapping.setPathPatterns(path);
+		this.jackson2HttpMessageConverter.setSupportedMediaTypes(
+				new ImmutableObservableList<>(MediaType.APPLICATION_JSON_UTF8, MediaType.TEXT_PLAIN));
 		super.setRequestMapping(requestMapping);
 		super.setStatusCodeExpression(new ValueExpression<>(HttpStatus.NO_CONTENT));
 		super.setMessageConverters(

--- a/src/main/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapter.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.aws.inbound;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -43,7 +44,6 @@ import org.springframework.web.multipart.MultipartResolver;
 
 import com.amazonaws.services.sns.AmazonSNS;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.sun.javafx.collections.ImmutableObservableList;
 
 /**
  * The {@link HttpRequestHandlingMessagingGateway} extension for the Amazon WS SNS HTTP(S) endpoints.
@@ -67,6 +67,7 @@ import com.sun.javafx.collections.ImmutableObservableList;
  * For the convenience on the underlying message flow routing a {@link AwsHeaders#SNS_MESSAGE_TYPE}
  * header is present.
  * @author Artem Bilan
+ * @author Kamil Przerwa
  */
 public class SnsInboundChannelAdapter extends HttpRequestHandlingMessagingGateway {
 
@@ -92,7 +93,7 @@ public class SnsInboundChannelAdapter extends HttpRequestHandlingMessagingGatewa
 		requestMapping.setHeaders("x-amz-sns-message-type");
 		requestMapping.setPathPatterns(path);
 		this.jackson2HttpMessageConverter.setSupportedMediaTypes(
-				new ImmutableObservableList<>(MediaType.APPLICATION_JSON_UTF8, MediaType.TEXT_PLAIN));
+				Arrays.asList(MediaType.APPLICATION_JSON_UTF8, MediaType.TEXT_PLAIN));
 		super.setRequestMapping(requestMapping);
 		super.setStatusCodeExpression(new ValueExpression<>(HttpStatus.NO_CONTENT));
 		super.setMessageConverters(

--- a/src/test/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapterTests.java
+++ b/src/test/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapterTests.java
@@ -54,6 +54,7 @@ import com.amazonaws.services.sns.AmazonSNS;
 
 /**
  * @author Artem Bilan
+ * @author Kamil Przerwa
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration
@@ -91,7 +92,7 @@ public class SnsInboundChannelAdapterTests {
 		this.mockMvc.perform(
 				post("/mySampleTopic")
 						.header("x-amz-sns-message-type", "SubscriptionConfirmation")
-						.contentType(MediaType.TEXT_PLAIN)
+						.contentType(MediaType.APPLICATION_JSON)
 						.content(StreamUtils.copyToByteArray(this.subscriptionConfirmation.getInputStream())))
 				.andExpect(status().isNoContent());
 

--- a/src/test/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapterTests.java
+++ b/src/test/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapterTests.java
@@ -91,7 +91,7 @@ public class SnsInboundChannelAdapterTests {
 		this.mockMvc.perform(
 				post("/mySampleTopic")
 						.header("x-amz-sns-message-type", "SubscriptionConfirmation")
-						.contentType(MediaType.APPLICATION_JSON)
+						.contentType(MediaType.TEXT_PLAIN)
 						.content(StreamUtils.copyToByteArray(this.subscriptionConfirmation.getInputStream())))
 				.andExpect(status().isNoContent());
 
@@ -116,7 +116,7 @@ public class SnsInboundChannelAdapterTests {
 		this.mockMvc.perform(
 				post("/mySampleTopic")
 						.header("x-amz-sns-message-type", "Notification")
-						.contentType(MediaType.APPLICATION_JSON)
+						.contentType(MediaType.TEXT_PLAIN)
 						.content(StreamUtils.copyToByteArray(this.notificationMessage.getInputStream())))
 				.andExpect(status().isNoContent());
 
@@ -133,7 +133,7 @@ public class SnsInboundChannelAdapterTests {
 		this.mockMvc.perform(
 				post("/mySampleTopic")
 						.header("x-amz-sns-message-type", "UnsubscribeConfirmation")
-						.contentType(MediaType.APPLICATION_JSON)
+						.contentType(MediaType.TEXT_PLAIN)
 						.content(StreamUtils.copyToByteArray(this.unsubscribeConfirmation.getInputStream())))
 				.andExpect(status().isNoContent());
 


### PR DESCRIPTION
- Modified supported content types for MappingJackson2HttpMessageConverter
- Updated unit tests

I have signed and agree to the terms of the SpringSource Individual Contributor License Agreement.