### PR TITLE
GH-41: Fix broken File upload.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ checkstyle {
 dependencies {
 
 	compile "org.springframework.integration:spring-integration-core:$springIntegrationVersion"
+	compile "org.springframework.cloud:spring-cloud-aws-core:$springCloudAwsVersion"
 	compile("org.springframework.cloud:spring-cloud-aws-messaging:$springCloudAwsVersion", optional)
 	compile("org.springframework.integration:spring-integration-file:$springIntegrationVersion", optional)
 	compile("org.springframework.integration:spring-integration-http:$springIntegrationVersion", optional)

--- a/src/main/java/org/springframework/integration/aws/outbound/S3MessageHandler.java
+++ b/src/main/java/org/springframework/integration/aws/outbound/S3MessageHandler.java
@@ -91,6 +91,7 @@ import com.amazonaws.util.Md5Utils;
  * {@link #destinationKeyExpression} are required and must not evaluate to {@code null}.
  *
  * @author Artem Bilan
+ * @author John Logan
  *
  * @see TransferManager
  */
@@ -315,10 +316,10 @@ public class S3MessageHandler extends AbstractReplyProducingMessageHandler {
 			try {
 				if (payload instanceof InputStream) {
 					InputStream inputStream = (InputStream) payload;
-					Assert.state(inputStream.markSupported(),
-							"The markSupported() method for an InputStream must evaluate to " +
-							"true for an upload request. ");
 					if (metadata.getContentMD5() == null) {
+						Assert.state(inputStream.markSupported(),
+								"For an upload InputStream with no MD5 digest metadata, the " +
+								"markSupported() method must evaluate to true. ");
 						String contentMd5 = Md5Utils.md5AsBase64(inputStream);
 						metadata.setContentMD5(contentMd5);
 						inputStream.reset();

--- a/src/main/java/org/springframework/integration/aws/outbound/S3MessageHandler.java
+++ b/src/main/java/org/springframework/integration/aws/outbound/S3MessageHandler.java
@@ -18,8 +18,6 @@ package org.springframework.integration.aws.outbound;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -35,7 +33,6 @@ import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
-import org.springframework.util.StreamUtils;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.event.ProgressEvent;
@@ -312,39 +309,63 @@ public class S3MessageHandler extends AbstractReplyProducingMessageHandler {
 			if (this.uploadMetadataProvider != null) {
 				this.uploadMetadataProvider.populateMetadata(metadata, requestMessage);
 			}
-			InputStream inputStream;
-			if (payload instanceof InputStream) {
-				inputStream = (InputStream) payload;
-			}
-			else if (payload instanceof File) {
-				File fileToUpload = (File) payload;
-				if (key == null) {
-					key = fileToUpload.getName();
-				}
-				try {
-					inputStream = new FileInputStream(fileToUpload);
 
+			PutObjectRequest putObjectRequest = null;
+
+			try {
+				if (payload instanceof InputStream) {
+					InputStream inputStream = (InputStream) payload;
+					Assert.state(inputStream.markSupported(),
+							"The markSupported() method for an InputStream must evaluate to " +
+							"true for an upload request. ");
+					if (metadata.getContentMD5() == null) {
+						String contentMd5 = Md5Utils.md5AsBase64(inputStream);
+						metadata.setContentMD5(contentMd5);
+						inputStream.reset();
+					}
+					putObjectRequest = new PutObjectRequest(bucketName, key, inputStream, metadata);
+				}
+				else if (payload instanceof File) {
+					File fileToUpload = (File) payload;
+					if (key == null) {
+						key = fileToUpload.getName();
+					}
+					if (metadata.getContentMD5() == null) {
+						String contentMd5 = Md5Utils.md5AsBase64(fileToUpload);
+						metadata.setContentMD5(contentMd5);
+					}
+					putObjectRequest = new PutObjectRequest(bucketName, key, fileToUpload).withMetadata(metadata);
 					if (metadata.getContentLength() == 0) {
 						metadata.setContentLength(fileToUpload.length());
 					}
 					if (metadata.getContentType() == null) {
 						metadata.setContentType(Mimetypes.getInstance().getMimetype(fileToUpload));
 					}
+				}
+				else if (payload instanceof byte[]) {
+					byte[] payloadBytes = (byte[]) payload;
+					InputStream inputStream = new ByteArrayInputStream(payloadBytes);
+					if (metadata.getContentMD5() == null) {
+						String contentMd5 = Md5Utils.md5AsBase64(inputStream);
+						metadata.setContentMD5(contentMd5);
+						inputStream.reset();
+					}
+					if (metadata.getContentLength() == 0) {
+						metadata.setContentLength(payloadBytes.length);
+					}
+					putObjectRequest = new PutObjectRequest(bucketName, key, inputStream, metadata);
+				}
+				else {
+					throw new IllegalArgumentException("Unsupported payload type: ["
+							+ payload.getClass()
+							+ "]. The only supported payloads for the upload request are " +
+							"java.io.File, java.io.InputStream, byte[] and PutObjectRequest.");
+				}
+			}
+			catch (IOException e) {
+				throw new MessageHandlingException(requestMessage, e);
+			}
 
-				}
-				catch (FileNotFoundException e) {
-					throw new AmazonClientException(e);
-				}
-			}
-			else if (payload instanceof byte[]) {
-				inputStream = new ByteArrayInputStream((byte[]) payload);
-			}
-			else {
-				throw new IllegalArgumentException("Unsupported payload type: ["
-						+ payload.getClass()
-						+ "]. The only supported payloads for the upload request are " +
-						"java.io.File, java.io.InputStream, byte[] and PutObjectRequest.");
-			}
 
 			Assert.state(key != null,
 					"The 'keyExpression' must not be null for non-File payloads and can't evaluate to null. " +
@@ -360,21 +381,6 @@ public class S3MessageHandler extends AbstractReplyProducingMessageHandler {
 					throw new IllegalStateException("Specify a 'keyExpression' for non-java.io.File payloads");
 				}
 			}
-
-			if (metadata.getContentMD5() == null) {
-				String contentMd5 = null;
-				try {
-					contentMd5 = Md5Utils.md5AsBase64(StreamUtils.copyToByteArray(inputStream));
-					if (inputStream.markSupported()) {
-						inputStream.reset();
-					}
-					metadata.setContentMD5(contentMd5);
-				}
-				catch (IOException e) {
-					throw new MessageHandlingException(requestMessage, e);
-				}
-			}
-			PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, key, inputStream, metadata);
 
 			S3ProgressListener progressListener = this.s3ProgressListener;
 

--- a/src/test/java/org/springframework/integration/aws/outbound/S3MessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/aws/outbound/S3MessageHandlerTests.java
@@ -101,6 +101,7 @@ import com.amazonaws.util.StringUtils;
 
 /**
  * @author Artem Bilan
+ * @author John Logan
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration


### PR DESCRIPTION
Fixes GH-41 (https://github.com/spring-projects/spring-integration-aws/issues/41)
Fixes GH-43 (https://github.com/spring-projects/spring-integration-aws/issues/43)

- Prior upload() code was trying to reset() a
  FileInputStream and then upload to S3, which
  resulted in zero uploaded bytes.
- Added dependency on spring-cloud-aws-core
  to resolve ResourceIdResolver reference.
- Fail if InputStream payload does not support
  mark/reset.
- Add metadata for byte array payload.