### PR TITLE
Issue #45: S3InboundFileSynchronizer failing when processing through …

### DIFF
--- a/src/main/java/org/springframework/integration/aws/support/S3Session.java
+++ b/src/main/java/org/springframework/integration/aws/support/S3Session.java
@@ -236,7 +236,7 @@ public class S3Session implements Session<S3ObjectSummary> {
 
 	private String[] splitPathToBucketAndKey(String path) {
 		Assert.hasText(path, "'path' must not be empty String.");
-		String[] bucketKey = path.split("/");
+		String[] bucketKey = path.split("/", 2);
 		Assert.state(bucketKey.length == 2, "'path' must in pattern [BUCKET/KEY].");
 		Assert.state(bucketKey[0].length() >= 3, "S3 bucket name must be at least 3 characters long.");
 		bucketKey[0] = resolveBucket(bucketKey[0]);

--- a/src/main/java/org/springframework/integration/aws/support/S3Session.java
+++ b/src/main/java/org/springframework/integration/aws/support/S3Session.java
@@ -43,6 +43,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
  * An Amazon S3 {@link Session} implementation.
  *
  * @author Artem Bilan
+ * @author Jim Krygowski
  */
 public class S3Session implements Session<S3ObjectSummary> {
 

--- a/src/test/java/org/springframework/integration/aws/inbound/S3InboundChannelAdapterTests.java
+++ b/src/test/java/org/springframework/integration/aws/inbound/S3InboundChannelAdapterTests.java
@@ -64,6 +64,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 
 /**
  * @author Artem Bilan
+ * @autor Jim Krygowski
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration

--- a/src/test/java/org/springframework/integration/aws/inbound/S3InboundChannelAdapterTests.java
+++ b/src/test/java/org/springframework/integration/aws/inbound/S3InboundChannelAdapterTests.java
@@ -100,7 +100,7 @@ public class S3InboundChannelAdapterTests {
 		for (File file : remoteFolder.listFiles()) {
 			S3Object s3Object = new S3Object();
 			s3Object.setBucketName(S3_BUCKET);
-			s3Object.setKey(file.getName());
+			s3Object.setKey("subdir/" + file.getName());
 			s3Object.setObjectContent(new FileInputStream(file));
 			S3_OBJECTS.add(s3Object);
 		}
@@ -191,7 +191,7 @@ public class S3InboundChannelAdapterTests {
 			synchronizer.setPreserveTimestamp(true);
 			synchronizer.setRemoteDirectory(S3_BUCKET);
 			synchronizer.setFilter(new S3RegexPatternFileListFilter(".*\\.test$"));
-			Expression expression = PARSER.parseExpression("#this.toUpperCase() + '.a'");
+			Expression expression = PARSER.parseExpression("(#this.contains('/') ? #this.substring(#this.lastIndexOf('/') + 1) : #this).toUpperCase() + '.a'");
 			synchronizer.setLocalFilenameGeneratorExpression(expression);
 			return synchronizer;
 		}


### PR DESCRIPTION
This pull request addresses an issue I encountered when trying to use the S3InboundFileSynchronizer on a bucket that was organized with subdirectories. The code in the method splitPathToBucketAndKey does not anticipate more than one forward slash <bucket>/<key>.  However for buckets with subdirectories there will be one or more slashes in the key. 

I modified the approach for splitPathToBucketAndKey to account for the fact that there will be more than one forward slash in the path when subdirectories are used in an S3 bucket. I set up the String.split operation to use the limit parameter to force the bucket identifier into the first element and the remainder of the text (the key) into the second element.

The unit tests continue to run and I've run a successful test of the code against a live S3 bucket organized with subdirectories.