### PR TITLE
Add start/stop queues management for SQS Adapter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		maven { url 'http://repo.spring.io/plugins-release' }
 	}
 	dependencies {
-		classpath 'io.spring.gradle:spring-io-plugin:0.0.4.RELEASE'
+		classpath 'io.spring.gradle:spring-io-plugin:0.0.5.RELEASE'
 	}
 }
 
@@ -56,7 +56,7 @@ ext {
 	servletApiVersion = '3.1.0'
 	slf4jVersion = '1.7.21'
 	springCloudAwsVersion = '1.1.0.RELEASE'
-	springIntegrationVersion = '4.2.8.RELEASE'
+	springIntegrationVersion = '4.2.9.RELEASE'
 
 	idPrefix = 'aws'
 

--- a/src/main/java/org/springframework/integration/aws/inbound/SqsMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/SqsMessageDrivenChannelAdapter.java
@@ -32,6 +32,9 @@ import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.integration.aws.support.AwsHeaders;
 import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.support.management.IntegrationManagedResource;
+import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.jmx.export.annotation.ManagedResource;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.core.DestinationResolver;
@@ -51,6 +54,8 @@ import com.amazonaws.services.sqs.AmazonSQSAsync;
  * @see SimpleMessageListenerContainer
  * @see QueueMessageHandler
  */
+@ManagedResource
+@IntegrationManagedResource
 public class SqsMessageDrivenChannelAdapter extends MessageProducerSupport implements DisposableBean {
 
 	private final SimpleMessageListenerContainerFactory simpleMessageListenerContainerFactory =
@@ -138,6 +143,21 @@ public class SqsMessageDrivenChannelAdapter extends MessageProducerSupport imple
 	@Override
 	protected void doStop() {
 		this.listenerContainer.stop();
+	}
+
+	@ManagedOperation
+	public void stop(String logicalQueueName) {
+		this.listenerContainer.stop(logicalQueueName);
+	}
+
+	@ManagedOperation
+	public void start(String logicalQueueName) {
+		this.listenerContainer.start(logicalQueueName);
+	}
+
+	@ManagedOperation
+	public boolean isRunning(String logicalQueueName) {
+		return this.listenerContainer.isRunning(logicalQueueName);
 	}
 
 	@Override

--- a/src/test/java/org/springframework/integration/aws/outbound/S3MessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/aws/outbound/S3MessageHandlerTests.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -317,7 +318,9 @@ public class S3MessageHandlerTests {
 			AmazonS3 amazonS3 = mock(AmazonS3.class);
 
 			given(amazonS3.putObject(any(PutObjectRequest.class))).willReturn(new PutObjectResult());
-			given(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).willReturn(new ObjectMetadata());
+			ObjectMetadata objectMetadata = new ObjectMetadata();
+			objectMetadata.setLastModified(new Date());
+			given(amazonS3.getObjectMetadata(any(GetObjectMetadataRequest.class))).willReturn(objectMetadata);
 			given(amazonS3.copyObject(any(CopyObjectRequest.class))).willReturn(new CopyObjectResult());
 
 			ObjectListing objectListing = spy(new ObjectListing());


### PR DESCRIPTION
Provide delegates for the SC-AWS `SimpleMessageListenerContainer` `start/stop/isRunning` method for individual queues.

Mark `SqsMessageDrivenChannelAdapter` with `@ManagedResource` and `@IntegrationManagedResource` to make those operation accessible from JMX/ControlBus
Cover the change with test-case
Provide some upgrades
Fix test for NPE from AWS SDK around `lastModified`: https://github.com/aws/aws-sdk-java/issues/822