### PR TITLE
Update spring-cloud-aws to version 1.1.3 to get proper timeout …

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The Java Configuration is pretty simple:
 public static class MyConfiguration {
 
     @Autowired
-    private AmazonSQS amazonSqs;
+    private AmazonSQSAsync amazonSqs;
 
     @Bean
     public QueueMessagingTemplate queueMessagingTemplate() {

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ ext {
 	assertjVersion = '3.5.2'
 	servletApiVersion = '3.1.0'
 	slf4jVersion = '1.7.21'
-	springCloudAwsVersion = '1.1.1.RELEASE'
+	springCloudAwsVersion = '1.1.3.RELEASE'
 	springIntegrationVersion = '4.3.2.RELEASE'
 
 	idPrefix = 'aws'

--- a/src/main/java/org/springframework/integration/aws/outbound/SqsMessageHandler.java
+++ b/src/main/java/org/springframework/integration/aws/outbound/SqsMessageHandler.java
@@ -28,7 +28,7 @@ import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
 
 /**
  * The {@link AbstractMessageHandler} implementation for the Amazon SQS {@code sendMessage}.
@@ -48,11 +48,11 @@ public class SqsMessageHandler extends AbstractMessageHandler {
 
 	private EvaluationContext evaluationContext;
 
-	public SqsMessageHandler(AmazonSQS amazonSqs) {
+	public SqsMessageHandler(AmazonSQSAsync amazonSqs) {
 		this(amazonSqs, null);
 	}
 
-	public SqsMessageHandler(AmazonSQS amazonSqs, ResourceIdResolver resourceIdResolver) {
+	public SqsMessageHandler(AmazonSQSAsync amazonSqs, ResourceIdResolver resourceIdResolver) {
 		this(new QueueMessagingTemplate(amazonSqs, resourceIdResolver));
 	}
 

--- a/src/test/java/org/springframework/integration/aws/outbound/SqsMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/aws/outbound/SqsMessageHandlerTests.java
@@ -30,7 +30,7 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
 import com.amazonaws.services.sqs.model.GetQueueUrlResult;
 
@@ -50,8 +50,8 @@ public class SqsMessageHandlerTests extends AbstractSqsMessageHandlerTests {
 	public static class ContextConfiguration {
 
 		@Bean
-		public AmazonSQS amazonSqs() {
-			AmazonSQS amazonSqs = mock(AmazonSQS.class);
+		public AmazonSQSAsync amazonSqs() {
+			AmazonSQSAsync amazonSqs = mock(AmazonSQSAsync.class);
 
 			willAnswer(invocation -> {
 				GetQueueUrlRequest getQueueUrlRequest = (GetQueueUrlRequest) invocation.getArguments()[0];

--- a/src/test/java/org/springframework/integration/aws/outbound/SqsMessageHandlerWithQueueMessagingTemplateTests.java
+++ b/src/test/java/org/springframework/integration/aws/outbound/SqsMessageHandlerWithQueueMessagingTemplateTests.java
@@ -31,7 +31,7 @@ import org.springframework.messaging.MessageHandler;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSAsync;
 import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
 import com.amazonaws.services.sqs.model.GetQueueUrlResult;
 
@@ -50,8 +50,8 @@ public class SqsMessageHandlerWithQueueMessagingTemplateTests extends AbstractSq
 	public static class ContextConfiguration {
 
 		@Bean
-		public AmazonSQS amazonSqs() {
-			AmazonSQS amazonSqs = mock(AmazonSQS.class);
+		public AmazonSQSAsync amazonSqs() {
+			AmazonSQSAsync amazonSqs = mock(AmazonSQSAsync.class);
 
 			willAnswer(invocation -> {
 				GetQueueUrlRequest getQueueUrlRequest = (GetQueueUrlRequest) invocation.getArguments()[0];


### PR DESCRIPTION
…behavior for SQS OCA rather than delay. Consistency with AmazonSQSAsync usage (Issue #49)

QueueMessageTemplate expects an AmazonSQSAsync client rather than an AmazonSQS. Looking at their commit for 1.1.3, it makes sense why they changed it, but it requires some minor changes here.
