### PR TITLE
Fix concurrent array modification in Kinesis inbound logic

### DIFF
--- a/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
@@ -26,8 +26,10 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -849,7 +851,7 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport i
 
 	private final class ConsumerInvoker implements SchedulingAwareRunnable {
 
-		private final List<ShardConsumer> consumers = new ArrayList<>();
+		private final Queue<ShardConsumer> consumers = new ConcurrentLinkedQueue<>();
 
 		ConsumerInvoker(Collection<ShardConsumer> shardConsumers) {
 			this.consumers.addAll(shardConsumers);


### PR DESCRIPTION
ConsumerInvoker uses iterator over 'consumers' field, which can be
concurrently modified in populateConsumer() method, thus triggering
ConcurrentModificationException:

Exception in thread "kinesisChannel-kinesis-consumer-1" java.util.ConcurrentModificationException
	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901)
	at java.util.ArrayList$Itr.next(ArrayList.java:851)
	at org.springframework.integration.aws.inbound.kinesis.KinesisMessageDrivenChannelAdapter$ConsumerInvoker.run(KinesisMessageDrivenChannelAdapter.java:866)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)

Using ConcurrentLinkedQueue instead of ArrayList fixes the problem.