### PR TITLE
Adding message producing capabilities to KinesisMessageHandler

### DIFF
--- a/src/main/java/org/springframework/integration/aws/outbound/KinesisMessageHandler.java
+++ b/src/main/java/org/springframework/integration/aws/outbound/KinesisMessageHandler.java
@@ -28,7 +28,7 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.aws.support.AwsHeaders;
-import org.springframework.integration.aws.support.AwsSendFailureException;
+import org.springframework.integration.aws.support.AwsRequestFailureException;
 import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.handler.AbstractMessageHandler;
@@ -170,7 +170,7 @@ public class KinesisMessageHandler extends AbstractMessageProducingHandler {
 
 	/**
 	 * Set the failure channel. After a send failure, an {@link ErrorMessage} will be sent
-	 * to this channel with a payload of a {@link AwsSendFailureException} with the
+	 * to this channel with a payload of a {@link AwsRequestFailureException} with the
 	 * failed message and cause.
 	 * @param sendFailureChannel the failure channel.
 	 * @since 1.1.0
@@ -194,7 +194,7 @@ public class KinesisMessageHandler extends AbstractMessageProducingHandler {
 
 	/**
 	 * Set the failure channel name. After a send failure, an {@link ErrorMessage} will be
-	 * sent to this channel name with a payload of a {@link AwsSendFailureException}
+	 * sent to this channel name with a payload of a {@link AwsRequestFailureException}
 	 * with the failed message and cause.
 	 * @param sendFailureChannelName the failure channel name.
 	 * @since 1.1.0
@@ -310,7 +310,7 @@ public class KinesisMessageHandler extends AbstractMessageProducingHandler {
 						if (getSendFailureChannel() != null) {
 							KinesisMessageHandler.this.messagingTemplate.send(getSendFailureChannel(),
 									KinesisMessageHandler.this.errorMessageStrategy.buildErrorMessage(
-											new AwsSendFailureException(message,
+											new AwsRequestFailureException(message,
 													(PutRecordsRequest) message.getPayload(), ex), null));
 						}
 					}
@@ -346,7 +346,7 @@ public class KinesisMessageHandler extends AbstractMessageProducingHandler {
 						if (getSendFailureChannel() != null) {
 							KinesisMessageHandler.this.messagingTemplate.send(getSendFailureChannel(),
 									KinesisMessageHandler.this.errorMessageStrategy.buildErrorMessage(
-											new AwsSendFailureException(message, request, ex), null));
+											new AwsRequestFailureException(message, request, ex), null));
 						}
 					}
 

--- a/src/main/java/org/springframework/integration/aws/outbound/KinesisMessageHandler.java
+++ b/src/main/java/org/springframework/integration/aws/outbound/KinesisMessageHandler.java
@@ -28,10 +28,16 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.aws.support.AwsHeaders;
+import org.springframework.integration.aws.support.AwsSendFailureException;
 import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.handler.AbstractMessageHandler;
+import org.springframework.integration.handler.AbstractMessageProducingHandler;
+import org.springframework.integration.support.DefaultErrorMessageStrategy;
+import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -47,12 +53,13 @@ import com.amazonaws.services.kinesis.model.PutRecordsResult;
  * The {@link AbstractMessageHandler} implementation for the Amazon Kinesis {@code putRecord(s)}.
  *
  * @author Artem Bilan
+ * @author Jacob Severson
  * @since 1.1
  *
  * @see AmazonKinesisAsync#putRecord(PutRecordRequest)
  * @see com.amazonaws.handlers.AsyncHandler
  */
-public class KinesisMessageHandler extends AbstractMessageHandler {
+public class KinesisMessageHandler extends AbstractMessageProducingHandler {
 
 	private static final long DEFAULT_SEND_TIMEOUT = 10000;
 
@@ -75,6 +82,12 @@ public class KinesisMessageHandler extends AbstractMessageHandler {
 	private boolean sync;
 
 	private Expression sendTimeoutExpression = new ValueExpression<>(DEFAULT_SEND_TIMEOUT);
+
+	private MessageChannel sendFailureChannel;
+
+	private String sendFailureChannelName;
+
+	private ErrorMessageStrategy errorMessageStrategy = new DefaultErrorMessageStrategy();
 
 	public KinesisMessageHandler(AmazonKinesisAsync amazonKinesis) {
 		Assert.notNull(amazonKinesis, "'amazonKinesis' must not be null.");
@@ -155,6 +168,41 @@ public class KinesisMessageHandler extends AbstractMessageHandler {
 		this.sendTimeoutExpression = sendTimeoutExpression;
 	}
 
+	/**
+	 * Set the failure channel. After a send failure, an {@link ErrorMessage} will be sent
+	 * to this channel with a payload of a {@link AwsSendFailureException} with the
+	 * failed message and cause.
+	 * @param sendFailureChannel the failure channel.
+	 * @since 1.1.0
+	 */
+	public void setSendFailureChannel(MessageChannel sendFailureChannel) {
+		this.sendFailureChannel = sendFailureChannel;
+	}
+
+	protected MessageChannel getSendFailureChannel() {
+		if (this.sendFailureChannel != null) {
+			return this.sendFailureChannel;
+
+		}
+		else if (this.sendFailureChannelName != null) {
+			this.sendFailureChannel = getChannelResolver().resolveDestination(this.sendFailureChannelName);
+			return this.sendFailureChannel;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Set the failure channel name. After a send failure, an {@link ErrorMessage} will be
+	 * sent to this channel name with a payload of a {@link AwsSendFailureException}
+	 * with the failed message and cause.
+	 * @param sendFailureChannelName the failure channel name.
+	 * @since 1.1.0
+	 */
+	public void setSendFailureChannelName(String sendFailureChannelName) {
+		this.sendFailureChannelName = sendFailureChannelName;
+	}
+
 	@Override
 	protected void onInit() throws Exception {
 		super.onInit();
@@ -163,19 +211,21 @@ public class KinesisMessageHandler extends AbstractMessageHandler {
 
 	@Override
 	@SuppressWarnings("unchecked")
-	protected void handleMessageInternal(Message<?> message) throws Exception {
+	protected void handleMessageInternal(final Message<?> message) throws Exception {
 		Future<?> resultFuture = null;
+
 		if (message.getPayload() instanceof PutRecordsRequest) {
+
 			resultFuture = this.amazonKinesis.putRecordsAsync((PutRecordsRequest) message.getPayload(),
-					(AsyncHandler<PutRecordsRequest, PutRecordsResult>) this.asyncHandler);
+					getPutRecordsAsyncHandler(message));
 		}
 		else {
-			PutRecordRequest putRecordRequest = (message.getPayload() instanceof PutRecordRequest)
+			final PutRecordRequest putRecordRequest = (message.getPayload() instanceof PutRecordRequest)
 					? (PutRecordRequest) message.getPayload()
 					: buildPutRecordRequest(message);
 
 			resultFuture = this.amazonKinesis.putRecordAsync(putRecordRequest,
-					(AsyncHandler<PutRecordRequest, PutRecordResult>) this.asyncHandler);
+					getPutRecordAsyncHandler(message, putRecordRequest));
 		}
 
 		if (this.sync) {
@@ -243,6 +293,76 @@ public class KinesisMessageHandler extends AbstractMessageHandler {
 				.withExplicitHashKey(explicitHashKey)
 				.withSequenceNumberForOrdering(sequenceNumber)
 				.withData(data);
+	}
+
+	@SuppressWarnings("unchecked")
+	private AsyncHandler<PutRecordsRequest, PutRecordsResult> getPutRecordsAsyncHandler(final Message<?> message) {
+		// allowing explicit setting of the AsyncHandler for backward compatibility
+		if (this.asyncHandler != null) {
+			return (AsyncHandler<PutRecordsRequest, PutRecordsResult>) this.asyncHandler;
+		}
+		else {
+			if (getSendFailureChannel() != null || getOutputChannel() != null) {
+				return new AsyncHandler<PutRecordsRequest, PutRecordsResult>() {
+
+					@Override
+					public void onError(Exception ex) {
+						if (getSendFailureChannel() != null) {
+							KinesisMessageHandler.this.messagingTemplate.send(getSendFailureChannel(),
+									KinesisMessageHandler.this.errorMessageStrategy.buildErrorMessage(
+											new AwsSendFailureException(message,
+													(PutRecordsRequest) message.getPayload(), ex), null));
+						}
+					}
+
+					@Override
+					public void onSuccess(PutRecordsRequest request, PutRecordsResult putRecordsResult) {
+						if (getOutputChannel() != null) {
+							KinesisMessageHandler.this.messagingTemplate.send(getOutputChannel(),
+									getMessageBuilderFactory().fromMessage(message).build());
+						}
+					}
+				};
+			}
+			else {
+				return null;
+			}
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private AsyncHandler<PutRecordRequest, PutRecordResult> getPutRecordAsyncHandler(final Message<?> message,
+																					final PutRecordRequest request) {
+		// allowing explicit setting of the AsyncHandler for backward compatibility
+		if (this.asyncHandler != null) {
+			return (AsyncHandler<PutRecordRequest, PutRecordResult>) this.asyncHandler;
+		}
+		else {
+			if (getSendFailureChannel() != null || getOutputChannel() != null) {
+				return new AsyncHandler<PutRecordRequest, PutRecordResult>() {
+
+					@Override
+					public void onError(Exception ex) {
+						if (getSendFailureChannel() != null) {
+							KinesisMessageHandler.this.messagingTemplate.send(getSendFailureChannel(),
+									KinesisMessageHandler.this.errorMessageStrategy.buildErrorMessage(
+											new AwsSendFailureException(message, request, ex), null));
+						}
+					}
+
+					@Override
+					public void onSuccess(PutRecordRequest request, PutRecordResult putRecordsResult) {
+						if (getOutputChannel() != null) {
+							KinesisMessageHandler.this.messagingTemplate.send(getOutputChannel(),
+									getMessageBuilderFactory().fromMessage(message).build());
+						}
+					}
+				};
+			}
+			else {
+				return null;
+			}
+		}
 	}
 
 }

--- a/src/main/java/org/springframework/integration/aws/support/AwsRequestFailureException.java
+++ b/src/main/java/org/springframework/integration/aws/support/AwsRequestFailureException.java
@@ -33,9 +33,9 @@ public class AwsRequestFailureException extends MessagingException {
 
 	private final AmazonWebServiceRequest request;
 
-	public AwsRequestFailureException(Message<?> message, AmazonWebServiceRequest record, Throwable cause) {
+	public AwsRequestFailureException(Message<?> message, AmazonWebServiceRequest request, Throwable cause) {
 		super(message, cause);
-		this.request = record;
+		this.request = request;
 	}
 
 	public AmazonWebServiceRequest getRequest() {

--- a/src/main/java/org/springframework/integration/aws/support/AwsRequestFailureException.java
+++ b/src/main/java/org/springframework/integration/aws/support/AwsRequestFailureException.java
@@ -27,24 +27,24 @@ import com.amazonaws.AmazonWebServiceRequest;
  * @author Jacob Severson
  * @since 1.1.0
  */
-public class AwsSendFailureException extends MessagingException {
+public class AwsRequestFailureException extends MessagingException {
 
 	private static final long serialVersionUID = 1L;
 
-	private final AmazonWebServiceRequest record;
+	private final AmazonWebServiceRequest request;
 
-	public AwsSendFailureException(Message<?> message, AmazonWebServiceRequest record, Throwable cause) {
+	public AwsRequestFailureException(Message<?> message, AmazonWebServiceRequest record, Throwable cause) {
 		super(message, cause);
-		this.record = record;
+		this.request = record;
 	}
 
-	public AmazonWebServiceRequest getRecord() {
-		return this.record;
+	public AmazonWebServiceRequest getRequest() {
+		return this.request;
 	}
 
 	@Override
 	public String toString() {
-		return super.toString() + " [record=" + this.record + "]";
+		return super.toString() + " [record=" + this.request + "]";
 	}
 
 }

--- a/src/main/java/org/springframework/integration/aws/support/AwsSendFailureException.java
+++ b/src/main/java/org/springframework/integration/aws/support/AwsSendFailureException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.aws.support;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+
+import com.amazonaws.AmazonWebServiceRequest;
+
+/**
+ * An exception that is the payload of an {@code ErrorMessage} when a send fails.
+ *
+ * @author Jacob Severson
+ * @since 1.1.0
+ */
+public class AwsSendFailureException extends MessagingException {
+
+	private static final long serialVersionUID = 1L;
+
+	private final AmazonWebServiceRequest record;
+
+	public AwsSendFailureException(Message<?> message, AmazonWebServiceRequest record, Throwable cause) {
+		super(message, cause);
+		this.record = record;
+	}
+
+	public AmazonWebServiceRequest getRecord() {
+		return this.record;
+	}
+
+	@Override
+	public String toString() {
+		return super.toString() + " [record=" + this.record + "]";
+	}
+
+}

--- a/src/test/java/org/springframework/integration/aws/outbound/KinesisProducingMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/aws/outbound/KinesisProducingMessageHandlerTests.java
@@ -36,7 +36,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.serializer.support.SerializingConverter;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.aws.support.AwsHeaders;
-import org.springframework.integration.aws.support.AwsSendFailureException;
+import org.springframework.integration.aws.support.AwsRequestFailureException;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.messaging.Message;
@@ -126,13 +126,13 @@ public class KinesisProducingMessageHandlerTests {
 		this.kinesisSendChannel.send(message);
 
 		Message<?> failed = this.errorChannel.receive(10000);
-		AwsSendFailureException putRecordFailure = (AwsSendFailureException) failed.getPayload();
+		AwsRequestFailureException putRecordFailure = (AwsRequestFailureException) failed.getPayload();
 		assertThat(putRecordFailure.getCause().getMessage()).isEqualTo("putRecordRequestEx");
-		assertThat(((PutRecordRequest) putRecordFailure.getRecord()).getStreamName()).isEqualTo("foo");
-		assertThat(((PutRecordRequest) putRecordFailure.getRecord()).getPartitionKey()).isEqualTo("fooKey");
-		assertThat(((PutRecordRequest) putRecordFailure.getRecord()).getSequenceNumberForOrdering()).isEqualTo("10");
-		assertThat(((PutRecordRequest) putRecordFailure.getRecord()).getExplicitHashKey()).isNull();
-		assertThat(((PutRecordRequest) putRecordFailure.getRecord())
+		assertThat(((PutRecordRequest) putRecordFailure.getRequest()).getStreamName()).isEqualTo("foo");
+		assertThat(((PutRecordRequest) putRecordFailure.getRequest()).getPartitionKey()).isEqualTo("fooKey");
+		assertThat(((PutRecordRequest) putRecordFailure.getRequest()).getSequenceNumberForOrdering()).isEqualTo("10");
+		assertThat(((PutRecordRequest) putRecordFailure.getRequest()).getExplicitHashKey()).isNull();
+		assertThat(((PutRecordRequest) putRecordFailure.getRequest())
 				.getData()).isEqualTo(ByteBuffer.wrap("message".getBytes()));
 
 		message = new GenericMessage<>(new PutRecordsRequest()
@@ -165,10 +165,10 @@ public class KinesisProducingMessageHandlerTests {
 		this.kinesisSendChannel.send(message);
 
 		failed = this.errorChannel.receive(10000);
-		AwsSendFailureException putRecordsFailure = (AwsSendFailureException) failed.getPayload();
+		AwsRequestFailureException putRecordsFailure = (AwsRequestFailureException) failed.getPayload();
 		assertThat(putRecordsFailure.getCause().getMessage()).isEqualTo("putRecordsRequestEx");
-		assertThat(((PutRecordsRequest) putRecordsFailure.getRecord()).getStreamName()).isEqualTo("myStream");
-		assertThat(((PutRecordsRequest) putRecordsFailure.getRecord()).getRecords())
+		assertThat(((PutRecordsRequest) putRecordsFailure.getRequest()).getStreamName()).isEqualTo("myStream");
+		assertThat(((PutRecordsRequest) putRecordsFailure.getRequest()).getRecords())
 				.containsExactlyInAnyOrder(new PutRecordsRequestEntry()
 						.withData(ByteBuffer.wrap("test".getBytes()))
 						.withPartitionKey("testKey"));

--- a/src/test/java/org/springframework/integration/aws/outbound/KinesisProducingMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/aws/outbound/KinesisProducingMessageHandlerTests.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.aws.outbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.Future;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.serializer.support.SerializingConverter;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.aws.support.AwsHeaders;
+import org.springframework.integration.aws.support.AwsSendFailureException;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.amazonaws.handlers.AsyncHandler;
+import com.amazonaws.services.kinesis.AmazonKinesisAsync;
+import com.amazonaws.services.kinesis.model.PutRecordRequest;
+import com.amazonaws.services.kinesis.model.PutRecordsRequest;
+import com.amazonaws.services.kinesis.model.PutRecordsRequestEntry;
+
+/**
+ * @author Jacob Severson
+ * @since 1.1.0
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+public class KinesisProducingMessageHandlerTests {
+
+	@Autowired
+	protected AmazonKinesisAsync amazonKinesis;
+
+	@Autowired
+	protected MessageChannel kinesisSendChannel;
+
+	@Autowired
+	protected KinesisMessageHandler kinesisMessageHandler;
+
+	@Autowired
+	protected PollableChannel errorChannel;
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testKinesisMessageHandler() {
+		Message<?> message = MessageBuilder.withPayload("message").build();
+		try {
+			this.kinesisSendChannel.send(message);
+		}
+		catch (Exception e) {
+			assertThat(e).isInstanceOf(MessageHandlingException.class);
+			assertThat(e.getCause()).isInstanceOf(IllegalStateException.class);
+			assertThat(e.getMessage()).contains("'stream' must not be null for sending a Kinesis record");
+		}
+
+		this.kinesisMessageHandler.setStream("foo");
+		try {
+			this.kinesisSendChannel.send(message);
+		}
+		catch (Exception e) {
+			assertThat(e).isInstanceOf(MessageHandlingException.class);
+			assertThat(e.getCause()).isInstanceOf(IllegalStateException.class);
+			assertThat(e.getMessage()).contains("'partitionKey' must not be null for sending a Kinesis record");
+		}
+
+		message = MessageBuilder.fromMessage(message)
+				.setHeader(AwsHeaders.PARTITION_KEY, "fooKey")
+				.setHeader(AwsHeaders.SEQUENCE_NUMBER, "10")
+				.build();
+
+		this.kinesisSendChannel.send(message);
+
+		ArgumentCaptor<PutRecordRequest> putRecordRequestArgumentCaptor =
+				ArgumentCaptor.forClass(PutRecordRequest.class);
+		verify(this.amazonKinesis).putRecordAsync(putRecordRequestArgumentCaptor.capture(),
+				any(AsyncHandler.class));
+
+		PutRecordRequest putRecordRequest = putRecordRequestArgumentCaptor.getValue();
+
+		assertThat(putRecordRequest.getStreamName()).isEqualTo("foo");
+		assertThat(putRecordRequest.getPartitionKey()).isEqualTo("fooKey");
+		assertThat(putRecordRequest.getSequenceNumberForOrdering()).isEqualTo("10");
+		assertThat(putRecordRequest.getExplicitHashKey()).isNull();
+		assertThat(putRecordRequest.getData()).isEqualTo(ByteBuffer.wrap("message".getBytes()));
+
+		message = MessageBuilder.fromMessage(message)
+				.setHeader(AwsHeaders.PARTITION_KEY, "fooKey")
+				.setHeader(AwsHeaders.SEQUENCE_NUMBER, "10")
+				.build();
+
+		this.kinesisSendChannel.send(message);
+
+		Message<?> failed = this.errorChannel.receive(10000);
+		AwsSendFailureException putRecordFailure = (AwsSendFailureException) failed.getPayload();
+		assertThat(putRecordFailure.getCause().getMessage()).isEqualTo("putRecordRequestEx");
+		assertThat(((PutRecordRequest) putRecordFailure.getRecord()).getStreamName()).isEqualTo("foo");
+		assertThat(((PutRecordRequest) putRecordFailure.getRecord()).getPartitionKey()).isEqualTo("fooKey");
+		assertThat(((PutRecordRequest) putRecordFailure.getRecord()).getSequenceNumberForOrdering()).isEqualTo("10");
+		assertThat(((PutRecordRequest) putRecordFailure.getRecord()).getExplicitHashKey()).isNull();
+		assertThat(((PutRecordRequest) putRecordFailure.getRecord())
+				.getData()).isEqualTo(ByteBuffer.wrap("message".getBytes()));
+
+		message = new GenericMessage<>(new PutRecordsRequest()
+				.withStreamName("myStream")
+				.withRecords(new PutRecordsRequestEntry()
+						.withData(ByteBuffer.wrap("test".getBytes()))
+						.withPartitionKey("testKey")));
+
+		this.kinesisSendChannel.send(message);
+
+		ArgumentCaptor<PutRecordsRequest> putRecordsRequestArgumentCaptor =
+				ArgumentCaptor.forClass(PutRecordsRequest.class);
+		verify(this.amazonKinesis).putRecordsAsync(putRecordsRequestArgumentCaptor.capture(),
+				any(AsyncHandler.class));
+
+		PutRecordsRequest putRecordsRequest = putRecordsRequestArgumentCaptor.getValue();
+
+		assertThat(putRecordsRequest.getStreamName()).isEqualTo("myStream");
+		assertThat(putRecordsRequest.getRecords())
+				.containsExactlyInAnyOrder(new PutRecordsRequestEntry()
+						.withData(ByteBuffer.wrap("test".getBytes()))
+						.withPartitionKey("testKey"));
+
+		message = new GenericMessage<>(new PutRecordsRequest()
+				.withStreamName("myStream")
+				.withRecords(new PutRecordsRequestEntry()
+						.withData(ByteBuffer.wrap("test".getBytes()))
+						.withPartitionKey("testKey")));
+
+		this.kinesisSendChannel.send(message);
+
+		failed = this.errorChannel.receive(10000);
+		AwsSendFailureException putRecordsFailure = (AwsSendFailureException) failed.getPayload();
+		assertThat(putRecordsFailure.getCause().getMessage()).isEqualTo("putRecordsRequestEx");
+		assertThat(((PutRecordsRequest) putRecordsFailure.getRecord()).getStreamName()).isEqualTo("myStream");
+		assertThat(((PutRecordsRequest) putRecordsFailure.getRecord()).getRecords())
+				.containsExactlyInAnyOrder(new PutRecordsRequestEntry()
+						.withData(ByteBuffer.wrap("test".getBytes()))
+						.withPartitionKey("testKey"));
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Bean
+		@SuppressWarnings("unchecked")
+		public AmazonKinesisAsync amazonKinesis() {
+			AmazonKinesisAsync mock = mock(AmazonKinesisAsync.class);
+
+			given(mock.putRecordAsync(any(PutRecordRequest.class), any(AsyncHandler.class)))
+					.willReturn(mock(Future.class))
+					.willAnswer(invocation -> {
+						AsyncHandler<?, ?> handler = invocation.getArgumentAt(1, AsyncHandler.class);
+						handler.onError(new RuntimeException("putRecordRequestEx"));
+						return mock(Future.class);
+					});
+
+
+			given(mock.putRecordsAsync(any(PutRecordsRequest.class), any(AsyncHandler.class)))
+					.willReturn(mock(Future.class))
+					.willAnswer(invocation -> {
+						AsyncHandler<?, ?> handler = invocation.getArgumentAt(1, AsyncHandler.class);
+						handler.onError(new RuntimeException("putRecordsRequestEx"));
+						return mock(Future.class);
+					});
+
+			return mock;
+		}
+
+		@Bean
+		public PollableChannel errorChannel() {
+			return new QueueChannel();
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "kinesisSendChannel")
+		public MessageHandler kinesisMessageHandler() {
+			KinesisMessageHandler kinesisMessageHandler = new KinesisMessageHandler(amazonKinesis());
+			kinesisMessageHandler.setSync(true);
+			kinesisMessageHandler.setSendFailureChannel(errorChannel());
+			kinesisMessageHandler.setConverter(new Converter<Object, byte[]>() {
+
+				private SerializingConverter serializingConverter = new SerializingConverter();
+
+				@Override
+				public byte[] convert(Object source) {
+					if (source instanceof String) {
+						return ((String) source).getBytes();
+					}
+					else {
+						return this.serializingConverter.convert(source);
+					}
+				}
+
+			});
+			return kinesisMessageHandler;
+		}
+
+	}
+
+}


### PR DESCRIPTION
This is groundwork to allow usage of a failure channel within the Kinesis binder per https://github.com/spring-cloud/spring-cloud-stream-binder-aws-kinesis/issues/10. This implementation is intended to be backward-compatible with respect to the current handling of `AsyncHandler`. Client code can still provide an `AsyncHandler`, but doing so precludes the usage of channels for successful or unsuccessful sends.