### PR TITLE
Make sure that we wait at least `leaseDuration` to acquire the lock.

### DIFF
--- a/src/main/java/org/springframework/integration/aws/lock/DynamoDbLockRegistry.java
+++ b/src/main/java/org/springframework/integration/aws/lock/DynamoDbLockRegistry.java
@@ -471,7 +471,7 @@ public class DynamoDbLockRegistry implements ExpirableLockRegistry, Initializing
 
 			this.acquireLockOptionsBuilder
 					.withAdditionalTimeToWaitForLock(additionalTimeToWait)
-					.withRefreshPeriod(DynamoDbLockRegistry.this.refreshPeriod);
+					.withRefreshPeriod(DEFAULT_REFRESH_PERIOD_MS);
 
 			boolean acquired = false;
 			try {

--- a/src/main/java/org/springframework/integration/aws/lock/DynamoDbLockRegistry.java
+++ b/src/main/java/org/springframework/integration/aws/lock/DynamoDbLockRegistry.java
@@ -467,11 +467,11 @@ public class DynamoDbLockRegistry implements ExpirableLockRegistry, Initializing
 				return false;
 			}
 
-			long additionalTimeToWait = TimeUnit.MILLISECONDS.convert(time, unit) - System.currentTimeMillis() + start;
+			long additionalTimeToWait = Math.max(TimeUnit.MILLISECONDS.convert(time, unit) - System.currentTimeMillis() + start, 0L);
 
 			this.acquireLockOptionsBuilder
 					.withAdditionalTimeToWaitForLock(additionalTimeToWait)
-					.withRefreshPeriod(0L);
+					.withRefreshPeriod(DynamoDbLockRegistry.this.refreshPeriod);
 
 			boolean acquired = false;
 			try {

--- a/src/main/java/org/springframework/integration/aws/lock/DynamoDbLockRegistry.java
+++ b/src/main/java/org/springframework/integration/aws/lock/DynamoDbLockRegistry.java
@@ -60,6 +60,7 @@ import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
  * Can create table in DynamoDB if an external {@link AmazonDynamoDBLockClient} is not provided.
  *
  * @author Artem Bilan
+ * @author Karl Lessard
  *
  * @since 2.0
  */
@@ -471,7 +472,7 @@ public class DynamoDbLockRegistry implements ExpirableLockRegistry, Initializing
 
 			this.acquireLockOptionsBuilder
 					.withAdditionalTimeToWaitForLock(additionalTimeToWait)
-					.withRefreshPeriod(DEFAULT_REFRESH_PERIOD_MS);
+					.withRefreshPeriod(DynamoDbLockRegistry.this.refreshPeriod);
 
 			boolean acquired = false;
 			try {


### PR DESCRIPTION
This fixes an issue where `additionalTimeToWait` has a negative value
that is subtracted later by the Amazon DynamoDB client to
`leaseDuration`, making it impossible to acquire the lock if expired.

Also allow to use the existing `refreshPeriod` properties in this case.

Ref: #97
CC: @artembilan 