### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	repositories {
-		maven { url 'http://repo.spring.io/plugins-release' }
+		maven { url 'https://repo.spring.io/plugins-release' }
 	}
 	dependencies {
 		classpath 'io.spring.gradle:spring-io-plugin:0.0.5.RELEASE'
@@ -26,7 +26,7 @@ repositories {
 	if (version.endsWith('BUILD-SNAPSHOT') || project.hasProperty('platformVersion')) {
 		maven { url 'https://repo.spring.io/libs-snapshot' }
 	}
-	maven { url 'http://repo.spring.io/libs-milestone' }
+	maven { url 'https://repo.spring.io/libs-milestone' }
 }
 
 compileJava {
@@ -69,7 +69,7 @@ ext {
 }
 
 ext.javadocLinks = [
-		"http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/"
+		"https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/"
 ] as String[]
 
 jacoco {

--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -34,12 +34,12 @@ def customizePom(pom, gradleProject) {
 			url = 'https://github.com/spring-projects/spring-integration-aws'
 			organization {
 				name = 'SpringSource'
-				url = 'http://springsource.org'
+				url = 'https://springsource.org'
 			}
 			licenses {
 				license {
 					name 'The Apache Software License, Version 2.0'
-					url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+					url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
 					distribution 'repo'
 				}
 			}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/ with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/ ([https](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://springsource.org with 1 occurrences migrated to:  
  https://springsource.org ([https](https://springsource.org) result 301).
* http://repo.spring.io/libs-milestone with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone ([https](https://repo.spring.io/libs-milestone) result 302).
* http://repo.spring.io/plugins-release with 1 occurrences migrated to:  
  https://repo.spring.io/plugins-release ([https](https://repo.spring.io/plugins-release) result 302).