### PR TITLE
URL Cleanup

### DIFF
--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files="package-info\.java" checks=".*" />
 	<suppress files="[\\/]test[\\/]" checks="AvoidStaticImport" />

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "https://www.puppycrawl.com/dtds/configuration_1_2.dtd">
 <module name="Checker">
 
 	<module name="SuppressionFilter">

--- a/src/test/java/org/springframework/integration/aws/config/xml/S3InboundChannelAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/S3InboundChannelAdapterParserTests-context.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xmlns:int="http://www.springframework.org/schema/integration"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-	   http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xmlns:int="https://www.springframework.org/schema/integration"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+	   https://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<bean id="s3" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="com.amazonaws.services.s3.AmazonS3"/>

--- a/src/test/java/org/springframework/integration/aws/config/xml/S3MessageHandlerParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/S3MessageHandlerParserTests-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd">
 
 	<bean id="s3" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="com.amazonaws.services.s3.AmazonS3"/>

--- a/src/test/java/org/springframework/integration/aws/config/xml/S3StreamingInboundChannelAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/S3StreamingInboundChannelAdapterParserTests-context.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xmlns:int="http://www.springframework.org/schema/integration"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-	   http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xmlns:int="https://www.springframework.org/schema/integration"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+	   https://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<bean id="s3" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="com.amazonaws.services.s3.AmazonS3"/>

--- a/src/test/java/org/springframework/integration/aws/config/xml/SnsInboundChannelAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SnsInboundChannelAdapterParserTests-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd">
 
 	<bean id="amazonSns" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="com.amazonaws.services.sns.AmazonSNS"/>

--- a/src/test/java/org/springframework/integration/aws/config/xml/SnsOutboundChannelAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SnsOutboundChannelAdapterParserTests-context.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xmlns:int="http://www.springframework.org/schema/integration"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-	   http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xmlns:int="https://www.springframework.org/schema/integration"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+	   https://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<bean id="amazonSns" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="com.amazonaws.services.sns.AmazonSNSAsync"/>

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageDrivenChannelAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageDrivenChannelAdapterParserTests-context.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-messaging:sqs-async-client id="sqs"/>
 

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageHandlerParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageHandlerParserTests-context.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xmlns:int="http://www.springframework.org/schema/integration"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-	   http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xmlns:int="https://www.springframework.org/schema/integration"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+	   https://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-messaging:sqs-async-client id="sqs"/>
 

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-messaging:sqs-async-client id="sqs"/>
 

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad2.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad2.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-messaging:sqs-async-client id="sqs"/>
 

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad3.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad3.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-messaging:sqs-async-client id="sqs"/>
 

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad4.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad4.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-messaging:sqs-async-client id="sqs"/>
 

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-good.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-good.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xmlns:int-aws="http://www.springframework.org/schema/integration/aws"
-	   xmlns:aws-messaging="http://www.springframework.org/schema/cloud/aws/messaging"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/integration/aws http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
-	   http://www.springframework.org/schema/cloud/aws/messaging http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
+<beans xmlns="https://www.springframework.org/schema/beans"
+	   xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-aws="https://www.springframework.org/schema/integration/aws"
+	   xmlns:aws-messaging="https://www.springframework.org/schema/cloud/aws/messaging"
+	   xsi:schemaLocation="https://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   https://www.springframework.org/schema/integration/aws https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd
+	   https://www.springframework.org/schema/cloud/aws/messaging https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd">
 
 	<aws-messaging:sqs-async-client id="sqs"/>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.puppycrawl.com/dtds/configuration_1_2.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_2.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_2.dtd) result 404).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/messaging (404) with 14 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/messaging ([https](https://www.springframework.org/schema/cloud/aws/messaging) result 404).
* [ ] http://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd (404) with 7 occurrences migrated to:  
  https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd ([https](https://www.springframework.org/schema/cloud/aws/messaging/spring-cloud-aws-messaging.xsd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 12 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd with 12 occurrences migrated to:  
  https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd ([https](https://www.springframework.org/schema/integration/aws/spring-integration-aws.xsd) result 200).
* [ ] http://www.springframework.org/schema/integration/spring-integration.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* [ ] http://www.w3.org/2001/XMLSchema-instance with 12 occurrences migrated to:  
  https://www.w3.org/2001/XMLSchema-instance ([https](https://www.w3.org/2001/XMLSchema-instance) result 200).
* [ ] http://www.springframework.org/schema/beans with 24 occurrences migrated to:  
  https://www.springframework.org/schema/beans ([https](https://www.springframework.org/schema/beans) result 301).
* [ ] http://www.springframework.org/schema/integration with 8 occurrences migrated to:  
  https://www.springframework.org/schema/integration ([https](https://www.springframework.org/schema/integration) result 301).
* [ ] http://www.springframework.org/schema/integration/aws with 24 occurrences migrated to:  
  https://www.springframework.org/schema/integration/aws ([https](https://www.springframework.org/schema/integration/aws) result 301).