### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Spring Integration Extension for Amazon Web Services (AWS)
 Launched in 2006, [Amazon Web Services][] (AWS) provides key infrastructure services for business through
 its cloud computing platform. Using cloud computing businesses can adopt a new business model whereby they
 do not have to plan and invest in procuring their own IT infrastructure. They can use the infrastructure and services
-provided by the cloud service provider and pay as they use the services. Visit [http://aws.amazon.com/products/]
+provided by the cloud service provider and pay as they use the services. Visit [https://aws.amazon.com/products/]
 for more details about various products offered by Amazon as a part their cloud computing services.
 
 *Spring Integration Extension for Amazon Web Services* provides Spring Integration adapters for the various services
@@ -422,11 +422,11 @@ By default the `SnsMessageHandler` is one-way `MessageHandler`.
 
 
 [Spring Cloud AWS]: https://github.com/spring-cloud/spring-cloud-aws
-[AWS SDK for Java]: http://aws.amazon.com/sdkforjava/
-[Amazon Web Services]: http://aws.amazon.com/
-[http://aws.amazon.com/products/]: http://aws.amazon.com/products/
-[http://aws.amazon.com/ses/]: http://aws.amazon.com/ses/
-[http://aws.amazon.com/documentation/ses/]: http://aws.amazon.com/documentation/ses/
-[Reference Manual]: http://docs.spring.io/spring-integration/reference/html/ftp.html
-[Pull requests]: http://help.github.com/send-pull-requests
+[AWS SDK for Java]: https://aws.amazon.com/sdkforjava/
+[Amazon Web Services]: https://aws.amazon.com/
+[https://aws.amazon.com/products/]: https://aws.amazon.com/products/
+[https://aws.amazon.com/ses/]: https://aws.amazon.com/ses/
+[https://aws.amazon.com/documentation/ses/]: https://aws.amazon.com/documentation/ses/
+[Reference Manual]: https://docs.spring.io/spring-integration/reference/html/ftp.html
+[Pull requests]: https://help.github.com/send-pull-requests
 [contributor guidelines]: https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -5,7 +5,7 @@ This document is the API specification for Spring Integration AWS Support
 <div id="overviewBody">
     <p>
         For further API reference and developer documentation, see the
-        <a href="http://docs.spring.io/spring-integration/reference/" target="_top">Spring
+        <a href="https://docs.spring.io/spring-integration/reference/" target="_top">Spring
             Integration reference documentation</a>.
         That documentation contains more detailed, developer-targeted
         descriptions, with conceptual overviews, definitions of terms,
@@ -13,7 +13,7 @@ This document is the API specification for Spring Integration AWS Support
     </p>
 
     <p>
-        <a href="http://projects.spring.io/spring-integration/" target="_top">Spring
+        <a href="https://projects.spring.io/spring-integration/" target="_top">Spring
             Integration main project page</a>
 	</p>
 

--- a/src/dist/notice.txt
+++ b/src/dist/notice.txt
@@ -4,13 +4,13 @@
    ========================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternatively, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/src/main/resources/org/springframework/integration/aws/config/spring-integration-aws-1.0.xsd
+++ b/src/main/resources/org/springframework/integration/aws/config/spring-integration-aws-1.0.xsd
@@ -10,7 +10,7 @@
 	<xsd:import namespace="http://www.springframework.org/schema/beans"/>
 	<xsd:import namespace="http://www.springframework.org/schema/tool"/>
 	<xsd:import namespace="http://www.springframework.org/schema/integration"
-				schemaLocation="http://www.springframework.org/schema/integration/spring-integration.xsd"/>
+				schemaLocation="https://www.springframework.org/schema/integration/spring-integration.xsd"/>
 
 
 	<xsd:annotation>
@@ -576,7 +576,7 @@
 								to arrive if the are currently no messages on the queue.
 								Higher values will reduce poll request to the system significantly. The value should
 								be between 1 and 20. For more information read the
-								http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html
+								https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html
 								]]>
 							</xsd:documentation>
 						</xsd:annotation>

--- a/src/test/java/org/springframework/integration/aws/outbound/AbstractSqsMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/aws/outbound/AbstractSqsMessageHandlerTests.java
@@ -71,13 +71,13 @@ public abstract class AbstractSqsMessageHandlerTests {
 				ArgumentCaptor.forClass(SendMessageRequest.class);
 		verify(this.amazonSqs).sendMessage(sendMessageRequestArgumentCaptor.capture());
 		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
-				.isEqualTo("http://queue-url.com/foo");
+				.isEqualTo("https://queue-url.com/foo");
 
 		message = MessageBuilder.withPayload("message").setHeader(AwsHeaders.QUEUE, "bar").build();
 		this.sqsSendChannel.send(message);
 		verify(this.amazonSqs, times(2)).sendMessage(sendMessageRequestArgumentCaptor.capture());
 		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
-				.isEqualTo("http://queue-url.com/bar");
+				.isEqualTo("https://queue-url.com/bar");
 
 		SpelExpressionParser spelExpressionParser = new SpelExpressionParser();
 		Expression expression = spelExpressionParser.parseExpression("headers.foo");
@@ -86,7 +86,7 @@ public abstract class AbstractSqsMessageHandlerTests {
 		this.sqsSendChannel.send(message);
 		verify(this.amazonSqs, times(3)).sendMessage(sendMessageRequestArgumentCaptor.capture());
 		assertThat(sendMessageRequestArgumentCaptor.getValue().getQueueUrl())
-				.isEqualTo("http://queue-url.com/baz");
+				.isEqualTo("https://queue-url.com/baz");
 	}
 
 }

--- a/src/test/java/org/springframework/integration/aws/outbound/SqsMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/aws/outbound/SqsMessageHandlerTests.java
@@ -56,7 +56,7 @@ public class SqsMessageHandlerTests extends AbstractSqsMessageHandlerTests {
 			willAnswer(invocation -> {
 				GetQueueUrlRequest getQueueUrlRequest = (GetQueueUrlRequest) invocation.getArguments()[0];
 				GetQueueUrlResult queueUrl = new GetQueueUrlResult();
-				queueUrl.setQueueUrl("http://queue-url.com/" + getQueueUrlRequest.getQueueName());
+				queueUrl.setQueueUrl("https://queue-url.com/" + getQueueUrlRequest.getQueueName());
 				return queueUrl;
 			})
 					.given(amazonSqs)

--- a/src/test/java/org/springframework/integration/aws/outbound/SqsMessageHandlerWithQueueMessagingTemplateTests.java
+++ b/src/test/java/org/springframework/integration/aws/outbound/SqsMessageHandlerWithQueueMessagingTemplateTests.java
@@ -56,7 +56,7 @@ public class SqsMessageHandlerWithQueueMessagingTemplateTests extends AbstractSq
 			willAnswer(invocation -> {
 				GetQueueUrlRequest getQueueUrlRequest = (GetQueueUrlRequest) invocation.getArguments()[0];
 				GetQueueUrlResult queueUrl = new GetQueueUrlResult();
-				queueUrl.setQueueUrl("http://queue-url.com/" + getQueueUrlRequest.getQueueName());
+				queueUrl.setQueueUrl("https://queue-url.com/" + getQueueUrlRequest.getQueueName());
 				return queueUrl;
 			})
 					.given(amazonSqs)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://queue-url.com/ (UnknownHostException) with 2 occurrences migrated to:  
  https://queue-url.com/ ([https](https://queue-url.com/) result UnknownHostException).
* [ ] http://queue-url.com/bar (UnknownHostException) with 1 occurrences migrated to:  
  https://queue-url.com/bar ([https](https://queue-url.com/bar) result UnknownHostException).
* [ ] http://queue-url.com/baz (UnknownHostException) with 1 occurrences migrated to:  
  https://queue-url.com/baz ([https](https://queue-url.com/baz) result UnknownHostException).
* [ ] http://queue-url.com/foo (UnknownHostException) with 1 occurrences migrated to:  
  https://queue-url.com/foo ([https](https://queue-url.com/foo) result UnknownHostException).
* [ ] http://docs.spring.io/spring-integration/reference/html/ftp.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-integration/reference/html/ftp.html ([https](https://docs.spring.io/spring-integration/reference/html/ftp.html) result 404).
* [ ] http://help.github.com/send-pull-requests (404) with 1 occurrences migrated to:  
  https://help.github.com/send-pull-requests ([https](https://help.github.com/send-pull-requests) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://aws.amazon.com/ with 1 occurrences migrated to:  
  https://aws.amazon.com/ ([https](https://aws.amazon.com/) result 200).
* [ ] http://aws.amazon.com/products/ with 3 occurrences migrated to:  
  https://aws.amazon.com/products/ ([https](https://aws.amazon.com/products/) result 200).
* [ ] http://aws.amazon.com/ses/ with 2 occurrences migrated to:  
  https://aws.amazon.com/ses/ ([https](https://aws.amazon.com/ses/) result 200).
* [ ] http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html with 1 occurrences migrated to:  
  https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html ([https](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html) result 200).
* [ ] http://docs.spring.io/spring-integration/reference/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-integration/reference/ ([https](https://docs.spring.io/spring-integration/reference/) result 200).
* [ ] http://projects.spring.io/spring-integration/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-integration/ ([https](https://projects.spring.io/spring-integration/) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.springframework.org/schema/integration/spring-integration.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* [ ] http://aws.amazon.com/documentation/ses/ with 2 occurrences migrated to:  
  https://aws.amazon.com/documentation/ses/ ([https](https://aws.amazon.com/documentation/ses/) result 301).
* [ ] http://aws.amazon.com/sdkforjava/ with 1 occurrences migrated to:  
  https://aws.amazon.com/sdkforjava/ ([https](https://aws.amazon.com/sdkforjava/) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).

# Ignored
These URLs were intentionally ignored.

* http://testQueue.amazonaws.com with 2 occurrences
* http://www.springframework.org/schema/beans with 1 occurrences
* http://www.springframework.org/schema/integration with 2 occurrences
* http://www.springframework.org/schema/integration/aws with 2 occurrences
* http://www.springframework.org/schema/tool with 2 occurrences
* http://www.w3.org/2001/XMLSchema with 1 occurrences