### PR TITLE
Add "shards to consume" mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,22 @@ The `KinesisMessageDrivenChannelAdapter` iterates over its shards and tries to a
 If `LockRegistry` is not provided, no exclusive locking happens and all the shards are consumed by this `KinesisMessageDrivenChannelAdapter`. 
 See also `DynamoDbLockRegistry` for more information.
 
-Also the `KclMessageDrivenChannelAdapter` is provided for performing streams consumption by [Kinesis Client Library][].
+The `KinesisMessageDrivenChannelAdapter` can be configured with a `Function<List<Shard>, List<Shard>> shardListFilter` to filter the available, open, non-exhausted shards.
+This filter `Function` will be called each time the shard list is refreshed.
+
+For example, users may want to fully read any parent shards before starting to read their child shards.  This could be achieved as follows:
+
+```java
+    openShards -> {
+        Set<String> openShardIds = openShards.stream().map(Shard::getShardId).collect(Collectors.toSet());
+        // only return open shards which have no parent available for reading 
+        return openShards.stream()
+                .filter(shard -> !openShardIds.contains(shard.getParentShardId()))
+                .collect(Collectors.toList());
+        }
+```
+
+Also, the `KclMessageDrivenChannelAdapter` is provided for performing streams consumption by [Kinesis Client Library][].
 See its JavaDocs for more information. 
 
 ### Outbound Channel Adapter

--- a/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
@@ -40,6 +40,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.DisposableBean;
@@ -171,6 +172,9 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 	private volatile Future<?> shardConsumerManagerFuture;
 
 	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Nullable
+	private Function<List<Shard>, List<Shard>> shardsToConsumeMapper;
 
 	public KinesisMessageDrivenChannelAdapter(AmazonKinesis amazonKinesis, String... streams) {
 		Assert.notNull(amazonKinesis, "'amazonKinesis' must not be null.");
@@ -338,6 +342,17 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 	public void setBindSourceRecord(boolean bindSourceRecord) {
 		this.bindSourceRecord = bindSourceRecord;
 	}
+
+	/**
+	 * Specify a {@link Function Function&lt;List&lt;Shard&gt;, List&lt;Shard&gt;&gt;} to map the detected shards to
+	 * consume with user business logic.
+	 *
+	 * @param shardsToConsumeMapper the mapper Function
+	 */
+	public void setShardsToConsumeMapper(Function<List<Shard>, List<Shard>> shardsToConsumeMapper) {
+		this.shardsToConsumeMapper = shardsToConsumeMapper;
+	}
+
 
 	@Override
 	protected void onInit() {
@@ -618,19 +633,19 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 				if (endingSequenceNumber != null) {
 					String checkpoint = this.checkpointStore.get(key);
 
-					boolean skipClosedShard = checkpoint != null && new BigInteger(endingSequenceNumber)
+					boolean skipClosedAndExhaustedShard = checkpoint != null && new BigInteger(endingSequenceNumber)
 							.compareTo(new BigInteger(checkpoint)) <= 0;
 
 					if (logger.isTraceEnabled()) {
 						logger.trace("The shard [" + shard + "] in stream [" + stream
-								+ "] is closed CLOSED with endingSequenceNumber [" + endingSequenceNumber
+								+ "] is closed CLOSED and exhausted with endingSequenceNumber [" + endingSequenceNumber
 								+ "].\nThe last processed checkpoint is [" + checkpoint + "]."
-								+ (skipClosedShard ? "\nThe shard will be skipped." : ""));
+								+ (skipClosedAndExhaustedShard ? "\nThe shard will be skipped." : ""));
 					}
 
-					if (skipClosedShard) {
-						// Skip CLOSED shard which has been read before
-						// according a checkpoint
+					if (skipClosedAndExhaustedShard) {
+						// Skip CLOSED shard which has been exhausted
+						// according the checkpoint
 						continue;
 					}
 				}
@@ -649,8 +664,7 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 			sleep(this.describeStreamBackoff, new IllegalStateException(exceptionMessage), false);
 		}
 
-		return shardsToConsume;
-
+		return this.shardsToConsumeMapper != null ? this.shardsToConsumeMapper.apply(shardsToConsume) : shardsToConsume;
 	}
 
 	private void sleep(long sleepAmount, RuntimeException error, boolean interruptThread) {

--- a/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
@@ -174,7 +174,7 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 	private ApplicationEventPublisher applicationEventPublisher;
 
 	@Nullable
-	private Function<List<Shard>, List<Shard>> shardsToConsumeMapper;
+	private Function<List<Shard>, List<Shard>> shardListFilter;
 
 	public KinesisMessageDrivenChannelAdapter(AmazonKinesis amazonKinesis, String... streams) {
 		Assert.notNull(amazonKinesis, "'amazonKinesis' must not be null.");
@@ -344,15 +344,13 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 	}
 
 	/**
-	 * Specify a {@link Function Function&lt;List&lt;Shard&gt;, List&lt;Shard&gt;&gt;} to map the detected shards to
-	 * consume with user business logic.
-	 *
-	 * @param shardsToConsumeMapper the mapper Function
+	 * Specify a {@link Function Function&lt;List&lt;Shard&gt;, List&lt;Shard&gt;&gt;} to filter the shards which will
+	 * be read from.
+	 * @param shardListFilter the filter {@link Function Function&lt;List&lt;Shard&gt;, List&lt;Shard&gt;&gt;}
 	 */
-	public void setShardsToConsumeMapper(Function<List<Shard>, List<Shard>> shardsToConsumeMapper) {
-		this.shardsToConsumeMapper = shardsToConsumeMapper;
+	public void setShardListFilter(Function<List<Shard>, List<Shard>> shardListFilter) {
+		this.shardListFilter = shardListFilter;
 	}
-
 
 	@Override
 	protected void onInit() {
@@ -664,7 +662,7 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 			sleep(this.describeStreamBackoff, new IllegalStateException(exceptionMessage), false);
 		}
 
-		return this.shardsToConsumeMapper != null ? this.shardsToConsumeMapper.apply(shardsToConsume) : shardsToConsume;
+		return this.shardListFilter != null ? this.shardListFilter.apply(shardsToConsume) : shardsToConsume;
 	}
 
 	private void sleep(long sleepAmount, RuntimeException error, boolean interruptThread) {


### PR DESCRIPTION
For feature request GH-179
Add a  Function<List<Shard>, List<Shard>> field so the user can map detected shards to consume with their own business logic