### PR TITLE
GH-193: Upgrade spring-cloud-aws to 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ See `SqsHeaderMapper` implementation for more information and also consult with 
 
 ### Inbound Channel Adapter
 
-The SQS Inbound Channel Adapter is a `message-driven` implementation for the `MessageProducer` and is represented with `SqsMessageDrivenChannelAdapter`. This channel adapter is based on the `org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer` to receive messages from the provided `queues` in async manner and send an enhanced Spring Integration Message to the provided `MessageChannel`.
+The SQS Inbound Channel Adapter is a `message-driven` implementation for the `MessageProducer` and is represented with `SqsMessageDrivenChannelAdapter`. This channel adapter is based on the `io.awspring.cloud.messaging.listener.SimpleMessageListenerContainer` to receive messages from the provided `queues` in async manner and send an enhanced Spring Integration Message to the provided `MessageChannel`.
 The enhancements include `AwsHeaders.MESSAGE_ID`, `AwsHeaders.RECEIPT_HANDLE` and `AwsHeaders.RECEIVED_QUEUE` message headers.
 
 The Java Configuration is pretty simple:

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
 	servletApiVersion = '4.0.1'
     localstackVersion = '0.2.6'
 	log4jVersion = '2.14.1'
-	springCloudAwsVersion = '2.2.5.RELEASE'
+	springCloudAwsVersion = '2.3.0'
 	springIntegrationVersion = '5.5.0-SNAPSHOT'
 	kinesisClientVersion = '1.14.0'
 	kinesisProducerVersion = '0.14.3'
@@ -85,7 +85,7 @@ dependencyManagement {
 		enabled = false
 	}
 	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-aws-dependencies:$springCloudAwsVersion"
+		mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:$springCloudAwsVersion"
 		mavenBom "org.springframework.integration:spring-integration-bom:$springIntegrationVersion"
 		mavenBom "com.fasterxml.jackson:jackson-bom:$jacksonVersion"
 		mavenBom "org.junit:junit-bom:$junitVersion"
@@ -103,10 +103,10 @@ checkstyle {
 
 dependencies {
 	api 'org.springframework.integration:spring-integration-core'
-	api 'org.springframework.cloud:spring-cloud-aws-core'
+	api 'io.awspring.cloud:spring-cloud-aws-core'
 	api 'com.fasterxml.jackson.core:jackson-databind'
 
-	optionalApi 'org.springframework.cloud:spring-cloud-aws-messaging'
+	optionalApi 'io.awspring.cloud:spring-cloud-aws-messaging'
 	optionalApi 'org.springframework.integration:spring-integration-file'
 	optionalApi 'org.springframework.integration:spring-integration-http'
 

--- a/src/main/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.springframework.cloud.aws.messaging.endpoint.NotificationStatus;
-import org.springframework.cloud.aws.messaging.endpoint.NotificationStatusHandlerMethodArgumentResolver;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.http.HttpHeaders;
@@ -44,6 +42,8 @@ import org.springframework.web.multipart.MultipartResolver;
 
 import com.amazonaws.services.sns.AmazonSNS;
 import com.fasterxml.jackson.databind.JsonNode;
+import io.awspring.cloud.messaging.endpoint.NotificationStatus;
+import io.awspring.cloud.messaging.endpoint.NotificationStatusHandlerMethodArgumentResolver;
 
 /**
  * The {@link HttpRequestHandlingMessagingGateway} extension for the Amazon WS SNS HTTP(S)

--- a/src/main/java/org/springframework/integration/aws/inbound/SqsMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/SqsMessageDrivenChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,11 +24,6 @@ import java.util.Set;
 
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.DisposableBean;
-import org.springframework.cloud.aws.core.env.ResourceIdResolver;
-import org.springframework.cloud.aws.messaging.config.SimpleMessageListenerContainerFactory;
-import org.springframework.cloud.aws.messaging.listener.QueueMessageHandler;
-import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer;
-import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.integration.aws.support.AwsHeaders;
 import org.springframework.integration.endpoint.MessageProducerSupport;
@@ -43,6 +38,11 @@ import org.springframework.messaging.handler.HandlerMethod;
 import org.springframework.util.Assert;
 
 import com.amazonaws.services.sqs.AmazonSQSAsync;
+import io.awspring.cloud.core.env.ResourceIdResolver;
+import io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory;
+import io.awspring.cloud.messaging.listener.QueueMessageHandler;
+import io.awspring.cloud.messaging.listener.SimpleMessageListenerContainer;
+import io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy;
 
 /**
  * The {@link MessageProducerSupport} implementation for the Amazon SQS

--- a/src/main/java/org/springframework/integration/aws/outbound/S3MessageHandler.java
+++ b/src/main/java/org/springframework/integration/aws/outbound/S3MessageHandler.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
@@ -56,6 +55,7 @@ import com.amazonaws.services.s3.transfer.internal.S3ProgressListener;
 import com.amazonaws.services.s3.transfer.internal.S3ProgressListenerChain;
 import com.amazonaws.util.Base64;
 import com.amazonaws.util.Md5Utils;
+import io.awspring.cloud.core.env.ResourceIdResolver;
 
 /**
  * The {@link AbstractReplyProducingMessageHandler} implementation for the Amazon S3

--- a/src/main/java/org/springframework/integration/aws/outbound/SnsMessageHandler.java
+++ b/src/main/java/org/springframework/integration/aws/outbound/SnsMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
 
-import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.expression.Expression;
 import org.springframework.expression.TypeLocator;
 import org.springframework.expression.common.LiteralExpression;
@@ -39,6 +38,7 @@ import com.amazonaws.services.sns.AmazonSNSAsync;
 import com.amazonaws.services.sns.model.MessageAttributeValue;
 import com.amazonaws.services.sns.model.PublishRequest;
 import com.amazonaws.services.sns.model.PublishResult;
+import io.awspring.cloud.core.env.ResourceIdResolver;
 
 /**
  * The {@link AbstractAwsMessageHandler} implementation to send SNS Notifications

--- a/src/main/java/org/springframework/integration/aws/outbound/SqsMessageHandler.java
+++ b/src/main/java/org/springframework/integration/aws/outbound/SqsMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
 
-import org.springframework.cloud.aws.core.env.ResourceIdResolver;
-import org.springframework.cloud.aws.messaging.support.destination.DynamicQueueUrlDestinationResolver;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.aws.support.AwsHeaders;
@@ -45,6 +43,8 @@ import com.amazonaws.services.sqs.model.SendMessageBatchRequest;
 import com.amazonaws.services.sqs.model.SendMessageBatchResult;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
+import io.awspring.cloud.core.env.ResourceIdResolver;
+import io.awspring.cloud.messaging.support.destination.DynamicQueueUrlDestinationResolver;
 
 /**
  * The {@link AbstractMessageHandler} implementation for the Amazon SQS

--- a/src/main/java/org/springframework/integration/aws/support/AbstractMessageAttributesHeaderMapper.java
+++ b/src/main/java/org/springframework/integration/aws/support/AbstractMessageAttributesHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,13 +24,14 @@ import java.util.UUID;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.cloud.aws.messaging.core.MessageAttributeDataTypes;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.utils.PatternMatchUtils;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.MimeType;
 import org.springframework.util.NumberUtils;
+
+import io.awspring.cloud.messaging.core.MessageAttributeDataTypes;
 
 /**
  * Base {@link HeaderMapper} implementation for common logic in SQS and SNS around message

--- a/src/main/java/org/springframework/integration/aws/support/S3Session.java
+++ b/src/main/java/org/springframework/integration/aws/support/S3Session.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.http.HttpStatus;
 
-import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
@@ -40,6 +39,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import io.awspring.cloud.core.env.ResourceIdResolver;
 
 /**
  * An Amazon S3 {@link Session} implementation.

--- a/src/main/java/org/springframework/integration/aws/support/S3SessionFactory.java
+++ b/src/main/java/org/springframework/integration/aws/support/S3SessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.aws.support;
 
-import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.remote.session.SharedSessionCapable;
 import org.springframework.util.Assert;
@@ -24,6 +23,7 @@ import org.springframework.util.Assert;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import io.awspring.cloud.core.env.ResourceIdResolver;
 
 /**
  * An Amazon S3 specific {@link SessionFactory} implementation. Also this class implements

--- a/src/main/java/org/springframework/integration/aws/support/SqsHeaderMapper.java
+++ b/src/main/java/org/springframework/integration/aws/support/SqsHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import com.amazonaws.services.sqs.model.MessageAttributeValue;
  * headers to SQS message attributes.
  * <p>
  * The
- * {@link org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer}
+ * {@link io.awspring.cloud.messaging.listener.SimpleMessageListenerContainer}
  * maps all the SQS message attributes to the {@link MessageHeaders}.
  *
  * @author Artem Bilan

--- a/src/main/resources/org/springframework/integration/aws/config/spring-integration-aws.xsd
+++ b/src/main/resources/org/springframework/integration/aws/config/spring-integration-aws.xsd
@@ -237,11 +237,11 @@
 		<xsd:attribute name="resource-id-resolver">
 			<xsd:annotation>
 				<xsd:documentation>
-					The 'org.springframework.cloud.aws.core.env.ResourceIdResolver' bean reference.
+					The 'io.awspring.cloud.core.env.ResourceIdResolver' bean reference.
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+						<tool:expected-type type="io.awspring.cloud.core.env.ResourceIdResolver"/>
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -701,7 +701,7 @@
 								The 'org.springframework.core.task.AsyncTaskExecutor' to run the underlying listener
 								task
 								from the
-								'org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer'.
+								'io.awspring.cloud.messaging.listener.SimpleMessageListenerContainer'.
 							</xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
@@ -755,7 +755,7 @@
 								A reference to a bean that implements the
 								'org.springframework.messaging.core.DestinationResolver' interface.
 								E.g.
-								'org.springframework.cloud.aws.messaging.support.destination.DynamicQueueUrlDestinationResolver'
+								'io.awspring.cloud.messaging.support.destination.DynamicQueueUrlDestinationResolver'
 							</xsd:documentation>
 							<xsd:appinfo>
 								<tool:annotation kind="ref">
@@ -905,11 +905,11 @@
 		<xsd:attribute name="resource-id-resolver">
 			<xsd:annotation>
 				<xsd:documentation>
-					The 'org.springframework.cloud.aws.core.env.ResourceIdResolver' bean reference.
+					The 'io.awspring.cloud.core.env.ResourceIdResolver' bean reference.
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+						<tool:expected-type type="io.awspring.cloud.core.env.ResourceIdResolver"/>
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>
@@ -992,11 +992,11 @@
 		<xsd:attribute name="resource-id-resolver">
 			<xsd:annotation>
 				<xsd:documentation>
-					The 'org.springframework.cloud.aws.core.env.ResourceIdResolver' bean reference.
+					The 'io.awspring.cloud.core.env.ResourceIdResolver' bean reference.
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+						<tool:expected-type type="io.awspring.cloud.core.env.ResourceIdResolver"/>
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>

--- a/src/test/java/org/springframework/integration/aws/config/xml/S3MessageHandlerParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/S3MessageHandlerParserTests-context.xml
@@ -18,7 +18,7 @@
 	</bean>
 
 	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver" />
+		<constructor-arg value="io.awspring.cloud.core.env.ResourceIdResolver" />
 	</bean>
 
 	<int-aws:s3-outbound-channel-adapter s3="s3"

--- a/src/test/java/org/springframework/integration/aws/config/xml/S3MessageHandlerParserTests.java
+++ b/src/test/java/org/springframework/integration/aws/config/xml/S3MessageHandlerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.integration.aws.outbound.S3MessageHandler;
@@ -38,6 +37,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.internal.S3ProgressListener;
+import io.awspring.cloud.core.env.ResourceIdResolver;
 
 /**
  * @author Artem Bilan

--- a/src/test/java/org/springframework/integration/aws/config/xml/SnsOutboundChannelAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SnsOutboundChannelAdapterParserTests-context.xml
@@ -12,7 +12,7 @@
 	</bean>
 
 	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver" />
+		<constructor-arg value="io.awspring.cloud.core.env.ResourceIdResolver" />
 	</bean>
 
 	<bean id="errorMessageStrategy" class="org.mockito.Mockito" factory-method="mock">

--- a/src/test/java/org/springframework/integration/aws/config/xml/SnsOutboundChannelAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SnsOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.test.util.TestUtils;
@@ -33,6 +32,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.sns.AmazonSNSAsync;
+import io.awspring.cloud.core.env.ResourceIdResolver;
 
 /**
  * @author Artem Bilan

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageDrivenChannelAdapterParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageDrivenChannelAdapterParserTests-context.xml
@@ -10,7 +10,7 @@
 	<aws-messaging:sqs-async-client id="sqs"/>
 
 	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+		<constructor-arg value="io.awspring.cloud.core.env.ResourceIdResolver"/>
 	</bean>
 
 	<bean id="taskExecutor" class="org.mockito.Mockito" factory-method="mock">

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageDrivenChannelAdapterParserTests.java
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageDrivenChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.aws.core.env.ResourceIdResolver;
-import org.springframework.cloud.aws.messaging.listener.SimpleMessageListenerContainer;
-import org.springframework.cloud.aws.messaging.listener.SqsMessageDeletionPolicy;
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.integration.aws.inbound.SqsMessageDrivenChannelAdapter;
@@ -39,6 +36,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.amazonaws.services.sqs.AmazonSQS;
+import io.awspring.cloud.core.env.ResourceIdResolver;
+import io.awspring.cloud.messaging.listener.SimpleMessageListenerContainer;
+import io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy;
 
 /**
  * @author Artem Bilan

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageHandlerParserTests-context.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageHandlerParserTests-context.xml
@@ -12,7 +12,7 @@
 	<aws-messaging:sqs-async-client id="sqs"/>
 
 	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+		<constructor-arg value="io.awspring.cloud.core.env.ResourceIdResolver"/>
 	</bean>
 
 	<bean id="errorMessageStrategy" class="org.mockito.Mockito" factory-method="mock">

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageHandlerParserTests.java
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsMessageHandlerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cloud.aws.core.env.ResourceIdResolver;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.test.util.TestUtils;
@@ -34,6 +33,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.sqs.AmazonSQS;
+import io.awspring.cloud.core.env.ResourceIdResolver;
 
 /**
  * @author Artem Bilan

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad.xml
@@ -10,7 +10,7 @@
 	<aws-messaging:sqs-async-client id="sqs"/>
 
 	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+		<constructor-arg value="io.awspring.cloud.core.env.ResourceIdResolver"/>
 	</bean>
 
 	<aws-messaging:queue-messaging-template amazon-sqs="sqs" id="queueMessagingTemplate"/>

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad2.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad2.xml
@@ -10,7 +10,7 @@
 	<aws-messaging:sqs-async-client id="sqs"/>
 
 	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+		<constructor-arg value="io.awspring.cloud.core.env.ResourceIdResolver"/>
 	</bean>
 
 	<aws-messaging:queue-messaging-template amazon-sqs="sqs" id="queueMessagingTemplate"/>

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad3.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad3.xml
@@ -10,7 +10,7 @@
 	<aws-messaging:sqs-async-client id="sqs"/>
 
 	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+		<constructor-arg value="io.awspring.cloud.core.env.ResourceIdResolver"/>
 	</bean>
 
 	<aws-messaging:queue-messaging-template amazon-sqs="sqs" id="queueMessagingTemplate"/>

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad4.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-bad4.xml
@@ -10,7 +10,7 @@
 	<aws-messaging:sqs-async-client id="sqs"/>
 
 	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+		<constructor-arg value="io.awspring.cloud.core.env.ResourceIdResolver"/>
 	</bean>
 
 	<aws-messaging:queue-messaging-template amazon-sqs="sqs" id="queueMessagingTemplate"/>

--- a/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-good.xml
+++ b/src/test/java/org/springframework/integration/aws/config/xml/SqsOutboundChannelAdapterParserTests-context-good.xml
@@ -10,7 +10,7 @@
 	<aws-messaging:sqs-async-client id="sqs"/>
 
 	<bean id="resourceIdResolver" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.cloud.aws.core.env.ResourceIdResolver"/>
+		<constructor-arg value="io.awspring.cloud.core.env.ResourceIdResolver"/>
 	</bean>
 
 	<int-aws:sqs-outbound-channel-adapter sqs="sqs"

--- a/src/test/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapterTests.java
+++ b/src/test/java/org/springframework/integration/aws/inbound/SnsInboundChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import org.mockito.BDDMockito;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cloud.aws.messaging.endpoint.NotificationStatus;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
@@ -48,6 +47,7 @@ import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.amazonaws.services.sns.AmazonSNS;
+import io.awspring.cloud.messaging.endpoint.NotificationStatus;
 
 /**
  * @author Artem Bilan

--- a/src/test/java/org/springframework/integration/aws/inbound/SqsMessageDrivenChannelAdapterTests.java
+++ b/src/test/java/org/springframework/integration/aws/inbound/SqsMessageDrivenChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ public class SqsMessageDrivenChannelAdapterTests {
 	void testSqsMessageDrivenChannelAdapter() {
 		assertThat(
 				TestUtils.getPropertyValue(this.sqsMessageDrivenChannelAdapter, "listenerContainer.queueStopTimeout"))
-				.isEqualTo(10000L);
+				.isEqualTo(20000L);
 		org.springframework.messaging.Message<?> receive = this.inputChannel.receive(1000);
 		assertThat(receive).isNotNull();
 		assertThat((String) receive.getPayload()).isIn("messageContent", "messageContent2");

--- a/src/test/java/org/springframework/integration/aws/outbound/SqsMessageHandlerTests.java
+++ b/src/test/java/org/springframework/integration/aws/outbound/SqsMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.aws.messaging.support.destination.DynamicQueueUrlDestinationResolver;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.expression.Expression;
@@ -55,6 +54,7 @@ import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
 import com.amazonaws.services.sqs.model.GetQueueUrlResult;
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
+import io.awspring.cloud.messaging.support.destination.DynamicQueueUrlDestinationResolver;
 
 /**
  * Instantiating SqsMessageHandler using amazonSqs.


### PR DESCRIPTION
Upgraded `spring-cloud-aws` up to 2.3.0 pointing to the [latest repo](https://github.com/awspring/spring-cloud-aws).

Solves https://github.com/spring-projects/spring-integration-aws/issues/193.