### PR TITLE
fix(KinesisMessageDrivenChannelAdapter): added logic to not use the N…

### DIFF
--- a/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
@@ -1080,26 +1080,20 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 						if (CheckpointMode.manual.equals(KinesisMessageDrivenChannelAdapter.this.checkpointMode) &&
 								!records.isEmpty()) {
 							logger.info("Manual checkpointer. Must validate if should use getNextShardIterator()");
-							String lastRecordSequence;
-							if (records.size() == 1) {
-								lastRecordSequence = records.get(0).getSequenceNumber();
-							}
-							else {
-								lastRecordSequence = records.get(records.size() - 1).getSequenceNumber();
-							}
+							String lastRecordSequence = records.get(records.size() - 1).getSequenceNumber();
 							String lastCheckpointSequence = this.checkpointer.getCheckpoint();
 							if (lastCheckpointSequence.equals(lastRecordSequence)) {
 								logger.info("latestCheckpointSequence is same as latestRecordSequence. " +
 										"" +
 										"Should getNextShardIterator()");
-								// Means the manual checkpointer has processed the last record, we we should move forward
+								// Means the manual checkpointer has processed the last record, Should move forward
 								this.shardIterator = result.getNextShardIterator();
 							}
 							else {
 								logger.info("latestCheckpointSequence is not the same as latestRecordSequence" +
 										". Should Get a new iterator AFTER_SEQUENCE_NUMBER latestCheckpointSequence");
 								// Something wrong happened and not all records were processed.
-								// We must start from the latest known checkpoint
+								// Must start from the latest known checkpoint
 								KinesisShardOffset newOffset = new KinesisShardOffset(this.shardOffset);
 								newOffset.setSequenceNumber(lastCheckpointSequence);
 								newOffset.setIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER);

--- a/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
@@ -1079,6 +1079,7 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 						List<Record> records = result.getRecords();
 						if (CheckpointMode.manual.equals(KinesisMessageDrivenChannelAdapter.this.checkpointMode) &&
 								!records.isEmpty()) {
+							logger.info("Manual checkpointer. Must validate if should use getNextShardIterator()");
 							String lastRecordSequence;
 							if (records.size() == 1) {
 								lastRecordSequence = records.get(0).getSequenceNumber();
@@ -1088,10 +1089,15 @@ public class KinesisMessageDrivenChannelAdapter extends MessageProducerSupport
 							}
 							String lastCheckpointSequence = this.checkpointer.getCheckpoint();
 							if (lastCheckpointSequence.equals(lastRecordSequence)) {
+								logger.info("latestCheckpointSequence is same as latestRecordSequence. " +
+										"" +
+										"Should getNextShardIterator()");
 								// Means the manual checkpointer has processed the last record, we we should move forward
 								this.shardIterator = result.getNextShardIterator();
 							}
 							else {
+								logger.info("latestCheckpointSequence is not the same as latestRecordSequence" +
+										". Should Get a new iterator AFTER_SEQUENCE_NUMBER latestCheckpointSequence");
 								// Something wrong happened and not all records were processed.
 								// We must start from the latest known checkpoint
 								KinesisShardOffset newOffset = new KinesisShardOffset(this.shardOffset);

--- a/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/kinesis/KinesisMessageDrivenChannelAdapter.java
@@ -94,6 +94,7 @@ import com.amazonaws.services.kinesis.model.ShardIteratorType;
  * @author Dirk Bonhomme
  * @author Greg Eales
  * @author Asiel Caballero
+ * @author Jonathan Nagayoshi
  *
  * @since 1.1
  */

--- a/src/test/java/org/springframework/integration/aws/inbound/KinesisMessageDrivenChannelAdapterTests.java
+++ b/src/test/java/org/springframework/integration/aws/inbound/KinesisMessageDrivenChannelAdapterTests.java
@@ -76,6 +76,7 @@ import com.amazonaws.services.kinesis.model.Shard;
  * @author Matthias Wesolowski
  * @author Greg Eales
  * @author Asiel Caballero
+ * @author Jonathan Nagayoshi
  *
  * @since 1.1
  */

--- a/src/test/java/org/springframework/integration/aws/inbound/KinesisMessageDrivenChannelAdapterTests.java
+++ b/src/test/java/org/springframework/integration/aws/inbound/KinesisMessageDrivenChannelAdapterTests.java
@@ -201,6 +201,40 @@ public class KinesisMessageDrivenChannelAdapterTests {
 				.hasSize(2);
 
 		this.kinesisMessageDrivenChannelAdapter.stop();
+
+		this.kinesisMessageDrivenChannelAdapter.setListenerMode(ListenerMode.batch);
+		this.kinesisMessageDrivenChannelAdapter.setCheckpointMode(CheckpointMode.manual);
+		this.checkpointStore.put("SpringIntegration" + ":" + STREAM1 + ":" + "1", "2");
+
+		this.kinesisMessageDrivenChannelAdapter.start();
+
+		message = this.kinesisChannel.receive(10000);
+		assertThat(message).isNotNull();
+		assertThat(message.getPayload()).isInstanceOf(List.class);
+		List<String> messagePayload = (List<String>) message.getPayload();
+		assertThat(messagePayload).size().isEqualTo(3);
+
+		Object messageSequenceNumberHeader = message.getHeaders().get(AwsHeaders.RECEIVED_SEQUENCE_NUMBER);
+		assertThat(messageSequenceNumberHeader).isInstanceOf(List.class);
+		assertThat((List<String>) messageSequenceNumberHeader).contains("3");
+		// Set checkpoint to 3, this should prevent adapter from using next shard, since its not the latest record
+		// in the batch
+		checkpointer.checkpoint("3");
+
+		await().untilAsserted(
+				() -> assertThat(this.checkpointStore.get("SpringIntegration" + ":" + STREAM1 + ":" + "1"))
+						.isEqualTo("3"));
+		message = this.kinesisChannel.receive(10000);
+		assertThat(message).isNotNull();
+		assertThat(message.getPayload()).isInstanceOf(List.class);
+		messagePayload = (List<String>) message.getPayload();
+		assertThat(messagePayload).size().isEqualTo(2);
+		assertThat(messagePayload).contains("bar");
+		assertThat(messagePayload).contains("foobar");
+
+		this.kinesisMessageDrivenChannelAdapter.stop();
+
+
 	}
 
 	@Test
@@ -295,6 +329,36 @@ public class KinesisMessageDrivenChannelAdapterTests {
 					.willReturn(new GetRecordsResult().withNextShardIterator(shard1Iterator3)
 							.withRecords(new Record().withPartitionKey("partition1").withSequenceNumber("2")
 									.withData(ByteBuffer.wrap(serializingConverter.convert("bar")))));
+
+
+			String shard1Iterator5 = "shard1Iterator5";
+			String shard1Iterator6 = "shard1Iterator6";
+
+			given(amazonKinesis.getShardIterator(
+					KinesisShardOffset.afterSequenceNumber(STREAM1, "1", "2").toShardIteratorRequest()))
+					.willReturn(new GetShardIteratorResult().withShardIterator(shard1Iterator5));
+
+			given(amazonKinesis.getRecords(new GetRecordsRequest().withShardIterator(shard1Iterator5).withLimit(25)))
+					.willReturn(new GetRecordsResult().withNextShardIterator(shard1Iterator6)
+							.withRecords(new Record().withPartitionKey("partition1").withSequenceNumber("3")
+									.withData(ByteBuffer.wrap(serializingConverter.convert("foo"))),
+									new Record().withPartitionKey("partition1").withSequenceNumber("4")
+											.withData(ByteBuffer.wrap(serializingConverter.convert("bar"))),
+									new Record().withPartitionKey("partition1").withSequenceNumber("5")
+											.withData(ByteBuffer.wrap(serializingConverter.convert("foobar")))));
+
+
+			given(amazonKinesis.getShardIterator(
+					KinesisShardOffset.afterSequenceNumber(STREAM1, "1", "3").toShardIteratorRequest()))
+					.willReturn(new GetShardIteratorResult().withShardIterator(shard1Iterator6));
+
+			given(amazonKinesis.getRecords(new GetRecordsRequest().withShardIterator(shard1Iterator6).withLimit(25)))
+					.willReturn(new GetRecordsResult().withNextShardIterator(shard1Iterator6)
+							.withRecords(
+									new Record().withPartitionKey("partition1").withSequenceNumber("4")
+											.withData(ByteBuffer.wrap(serializingConverter.convert("bar"))),
+									new Record().withPartitionKey("partition1").withSequenceNumber("5")
+											.withData(ByteBuffer.wrap(serializingConverter.convert("foobar")))));
 
 			return amazonKinesis;
 		}


### PR DESCRIPTION
### The scenario
We are using [spring-cloud-stream-binder-aws-kinesis](https://github.com/spring-cloud/spring-cloud-stream-binder-aws-kinesis) to consume a Kinesis Stream with a Single Shard. This Consumer is processing in BATCH Mode, and it needs to process every record in the exact order they were put into the stream. This is a big important requirement. If any record in the stream fails to be processed, the consumer should stay on that record until it's processed. We can't ignore records, nor send it to a DLQ and keep processing the next records.
If a record fails to be processed, we are not allowed to continue processing the next records, because the sequence order is of utmost importance.

### The implementation
 To achieve this guaranteed sequence order, we have implemented a Manual Checkpointer, so every time a record is processed successfully, we manually checkpoint the record's sequence number. If a record throws an exception, we do not checkpoint that sequence number. This way, our Metadata store will always have the sequence number of the latest successfully processed record.

### The Problem

The problem lies withing the `this.shardIterator = result.getNextShardIterator();` code, that lives in the `KinesisMessageDrivenChannelAdapter` file. 

In the original code, after a batch of records is processed, regardless if they were all processed or not, the implementation will get the next shard iterator

```java

				GetRecordsRequest getRecordsRequest = new GetRecordsRequest();
				getRecordsRequest.setShardIterator(this.shardIterator);
				getRecordsRequest.setLimit(KinesisMessageDrivenChannelAdapter.this.recordsLimit);

				GetRecordsResult result = null;

				try {
					result = getRecords(getRecordsRequest);
					if (result != null) {
						List<Record> records = result.getRecords();

						if (!records.isEmpty()) {
							processRecords(records);
						}
					}
				}
				finally {
					attributesHolder.remove();
					if (result != null) {
							this.shardIterator = result.getNextShardIterator();
						
```
This is a problem, because the **nextShardIterator** will continue at the end of the current batch, which means it will fetch the next set of records. This was causing my Consumer to receive the next set of records, even tough my checkpointer had explicitly said that the latest processed record was not the latest record of the batch.

### The proposed solution

The solution would be to validate if the checkpoint is equal the SequenceNumber of the last record of the batch, and just if so, get the next shard iterator. Otherwise, we'd need to get a shard iterator AFTER_SEQUENCE_NUMBER=latest checkpoint

Please, I'm open to discussion if you guys think there's an alternative solution for this.
I have published this version to my mavenLocal, and tested it locally, and it's working perfectly. 
