### PR TITLE
Make logs louder about FIFO-attribute mismatches

### DIFF
--- a/src/main/java/org/springframework/integration/aws/outbound/SnsMessageHandler.java
+++ b/src/main/java/org/springframework/integration/aws/outbound/SnsMessageHandler.java
@@ -222,7 +222,7 @@ public class SnsMessageHandler extends AbstractAwsMessageHandler<Map<String, Mes
 
 			if (this.messageGroupIdExpression != null) {
 				if (!topicArn.endsWith(".fifo")) {
-					logger.warn(LogMessage.format("a messageGroupId will be set for non-FIFO topic '%s'", topicArn));
+					logger.error(LogMessage.format("a messageGroupId will be set for non-FIFO topic '%s'; this message may be silently dropped", topicArn));
 				}
 				String messageGroupId =
 						this.messageGroupIdExpression.getValue(getEvaluationContext(), message, String.class);
@@ -231,8 +231,8 @@ public class SnsMessageHandler extends AbstractAwsMessageHandler<Map<String, Mes
 
 			if (this.messageDeduplicationIdExpression != null) {
 				if (!topicArn.endsWith(".fifo")) {
-					logger.warn(
-							LogMessage.format("a messageDeduplicationId will be set for non-FIFO topic '%s'", topicArn));
+					logger.error(
+							LogMessage.format("a messageDeduplicationId will be set for non-FIFO topic '%s'; this message may be silently dropped", topicArn));
 				}
 				String messageDeduplicationId =
 						this.messageDeduplicationIdExpression.getValue(getEvaluationContext(), message, String.class);


### PR DESCRIPTION
I discovered after using the new FIFO support that if the messageGroupId and/or messageDeduplicationId is set on a message published to a non-FIFO queue, Amazon will accept the message but will drop it on the floor. This commit raises the logs for this circumstance from WARN to ERROR.

I can also see that it might make sense to throw an exception instead, and that would be my preferred solution but is a larger change. Let me know if an exception is warranted, and if so I'll change the code to throw it.