### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ The Java Config looks like:
 @Bean
 public MessageHandler snsMessageHandler() {
     SnsMessageHandler handler = new SnsMessageHandler(amazonSns());
-    adapter.setTopicArn("arn:aws:sns:eu-west:123456789012:test");
+    handler.setTopicArn("arn:aws:sns:eu-west:123456789012:test");
     String bodyExpression = "T(SnsBodyBuilder).withDefault(payload).forProtocols(payload.substring(0, 140), 'sms')";
     handler.setBodyExpression(spelExpressionParser.parseExpression(bodyExpression));
 


### PR DESCRIPTION
Fix readme example referencing a non-existent variable.

While trying to use this library, I've found the example references this variable that doesn't exist in that context.
I'm not certain though since I don't have it all working yet, but the proposed change seems like what was originally intended here.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
