### PR TITLE
GH-247: Fix java.nio.ReadOnlyBufferException thrown by KclMessageDrivenChannelAdapter in batch mode

### DIFF
--- a/src/main/java/org/springframework/integration/aws/inbound/kinesis/KclMessageDrivenChannelAdapter.java
+++ b/src/main/java/org/springframework/integration/aws/inbound/kinesis/KclMessageDrivenChannelAdapter.java
@@ -713,7 +713,7 @@ public class KclMessageDrivenChannelAdapter extends MessageProducerSupport
 							partitionKeys.add(r.partitionKey());
 							sequenceNumbers.add(r.sequenceNumber());
 
-							return KclMessageDrivenChannelAdapter.this.converter.convert(r.data().array());
+							return KclMessageDrivenChannelAdapter.this.converter.convert(BinaryUtils.copyAllBytesFrom(r.data()));
 						})
 						.toList();
 


### PR DESCRIPTION
Fix for #247 

### Changes 
- Use BinaryUtils.copyAllBytes to fix java.nio.ReadOnlyBufferException thrown when processing batch records in KclMessageDrivenAdapter
- Improve test time by more than a couple minutes by initialising the lease table 

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
